### PR TITLE
Replaced sleeps with an event

### DIFF
--- a/Source/Hamakaze/drvmap.h
+++ b/Source/Hamakaze/drvmap.h
@@ -62,6 +62,22 @@ typedef VOID(NTAPI* pfnIofCompleteRequest)(
     _In_ VOID* Irp,
     _In_ CCHAR PriorityBoost);
 
+typedef NTSTATUS(NTAPI* pfnObReferenceObjectByHandle)(
+    _In_ HANDLE Handle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_opt_ POBJECT_TYPE ObjectType,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _Out_ PVOID* Object,
+    _Out_opt_ PVOID HandleInformation);
+
+typedef VOID(NTAPI* pfnObfDereferenceObject)(
+    _In_ PVOID Object);
+
+typedef NTSTATUS(NTAPI* pfnKeSetEvent)(
+    _In_ PKEVENT Event,
+    _In_ KPRIORITY Increment,
+    _In_ _Literal_ BOOLEAN Wait);
+
 typedef struct _FUNC_TABLE {
     pfnExAllocatePool ExAllocatePool;
     pfnExFreePool ExFreePool;
@@ -71,6 +87,9 @@ typedef struct _FUNC_TABLE {
     pfnZwOpenKey ZwOpenKey;
     pfnZwQueryValueKey ZwQueryValueKey;
     pfnZwDeleteValueKey ZwDeleteValueKey;
+    pfnObReferenceObjectByHandle ObReferenceObjectByHandle;
+    pfnObfDereferenceObject ObfDereferenceObject;
+    pfnKeSetEvent KeSetEvent;
    // pfnDbgPrint DbgPrint;
 } FUNC_TABLE, * PFUNC_TABLE;
 


### PR DESCRIPTION
**Description of the problem I am trying to fix:**  
The original implementation suspends execution for a fixed amount of time in order to simulate waiting for the ``FakeDispatchRoutine`` to finish:

```c
Sleep(1000);
supOpenDriver((LPWSTR)PROCEXP152, GENERIC_READ| GENERIC_WRITE, &victimDeviceHandle);
Sleep(1000);
```

There may be edge cases in which the execution of the fake dispatch routine does not finish in time.  
When the execution does not finish in time, KDU would falsely report success before knowing our dispatch routine has finished.
Such behavior might be caused by other external software like anti-viruses suspending threads or slowing down the computer in other means.


**My proposed solution:**
Create a waitable event in usermode with ``CreateEvent``, wait for it to get signaled using ``WaitForSingleObject`` and finally fire this event from the fake dispatch routine using ``KeSetEvent``.