### PR TITLE
PPL WinTcb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It features:
 * -prv  - optional, select vulnerable driver provider;
 * -ps   - modify process object of given ProcessID, downgrading any protections;
 * -pse  - launch program as ProtectedProcessLight-AntiMalware (PPL);
+* -psw  - launch program as ProtectedProcessLight-WinTcb (PPL);
 * -dmp  - dump virtual memory of the given process;
 * -dse  - write user-defined value to the system DSE state flags;
 * -map  - map driver to the kernel and execute its entry point; this command has dependencies listed below;
@@ -51,6 +52,11 @@ Example:
 + kdu -dse 0
 + kdu -dse 6
 + kdu -pse "C:\Windows\System32\notepad.exe C:\TEMP\words.txt"
++ kdu -psw "C:\Windows\System32\cmd.exe"
+
+Run on Windows 11 24H2*
+
+<img width="1181" height="563" alt="image" src="https://github.com/user-attachments/assets/bbdf6d18-bc74-41e2-a7cf-297e439ec9df" />
 
 Run on Windows 10 20H2*
 

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -24,6 +24,7 @@
 #define CMD_SCV         L"-scv"
 #define CMD_PS          L"-ps"
 #define CMD_PSE         L"-pse"
+#define CMD_PSW         L"-psw"
 #define CMD_DMP         L"-dmp"
 #define CMD_DSE         L"-dse"
 #define CMD_LIST        L"-list"
@@ -40,7 +41,8 @@
                      "kdu -list         - List available providers\r\n"\
                      "kdu -diag         - Run system diagnostic for troubleshooting\r\n"\
                      "kdu -prv id       - Optional, sets provider id to be used with rest of commands, default 0\r\n"\
-                     "kdu -pse cmdline  - Launch program as PPL\r\n"\
+                     "kdu -pse cmdline  - Launch program as PsProtectedSignerAntimalware-Light\r\n"\
+                     "kdu -psw cmdline  - Launch program as PsProtectedSignerWinTcb-Light\r\n"\
                      "kdu -dmp pid      - Dump virtual memory of the given process\r\n"\
                      "kdu -ps pid       - Disable ProtectedProcess for given pid\r\n"\
                      "kdu -dse value    - Write user defined value to the system DSE state flags\r\n"\
@@ -87,14 +89,15 @@ INT KDUProcessDmpSwitch(
 *
 * Purpose:
 *
-* Handle -pse switch.
+* Handle -pse and -psw switch.
 *
 */
 INT KDUProcessPSEObjectSwitch(
     _In_ ULONG HvciEnabled,
     _In_ ULONG NtBuildNumber,
     _In_ ULONG ProviderId,
-    _In_ LPWSTR CommandLine
+    _In_ LPWSTR CommandLine,
+    _In_ BOOL HighestSigner
 )
 {
     INT retVal = 0;
@@ -107,7 +110,7 @@ INT KDUProcessPSEObjectSwitch(
         ActionTypeDKOM);
 
     if (provContext) {
-        retVal = KDURunCommandPPL(provContext, CommandLine);
+        retVal = KDURunCommandPPL(provContext, CommandLine, HighestSigner);
         KDUProviderRelease(provContext);
     }
 
@@ -544,7 +547,21 @@ INT KDUProcessCommandLine(
                     retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
                         NtBuildNumber,
                         providerId,
-                        szParameter);
+                        szParameter,
+                        FALSE);
+                }
+
+                else if (supGetCommandLineOption(CMD_PSW,
+                    TRUE,
+                    szParameter,
+                    RTL_NUMBER_OF(szParameter),
+                    NULL))
+                {
+                    retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        szParameter, 
+                        TRUE);
                 }
 
                 else if (supGetCommandLineOption(CMD_DMP,

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -37,7 +37,8 @@ BOOL KDUUnprotectProcess(
 
 BOOL KDURunCommandPPL(
     _In_ PKDU_CONTEXT Context,
-    _In_ LPWSTR CommandLine);
+    _In_ LPWSTR CommandLine,
+    _In_ BOOL HighestSigner);
 
 BOOL KDUDumpProcessMemory(
     _In_ PKDU_CONTEXT Context,


### PR DESCRIPTION
* adding -psw switch
  * runs a process as PsProtectedSignerWinTcb-Light (0x61)
* print process protection (description, not just 0x31 / 0x61) again after kernel memory modified
```
[+] Kernel memory read at FFFFD18C294CC67A succeeded
        PsProtection->Type: 0 (PsProtectedTypeNone)
        PsProtection->Signer: 0 (PsProtectedSignerNone)
        PsProtection->Audit: 0
[+] Process object modified
[+] Kernel memory read at FFFFD18C294CC67A succeeded
        New PsProtection: 0x61
        PsProtection->Type: 1 (PsProtectedTypeProtectedLight)
        PsProtection->Signer: 6 (PsProtectedSignerWinTcb)
        PsProtection->Audit: 0
```