### PR TITLE
Add Process Mitigation stripping

### DIFF
--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -29,11 +29,22 @@
 #define PsProtectionOffset_19041 (ULONG_PTR)0x87A //same for 19042..19045
 #define PsProtectionOffset_26100 (ULONG_PTR)0x5FA
 
+#define PsMitigationFlags1Offset_26100 (ULONG_PTR)0x750
+#define PsMitigationFlags2Offset_26100 (ULONG_PTR)0x754
+
 #define EPROCESS_TO_PROTECTION(Object, PsProtectionOffset) ((ULONG_PTR)Object + (ULONG_PTR)PsProtectionOffset)
+
+#define EPROCESS_TO_MITIGATIONFLAGS1(Object, PsMitigationOffset) ((ULONG_PTR)Object + (ULONG_PTR)PsMitigationOffset)
+#define EPROCESS_TO_MITIGATIONFLAGS2(Object, PsMitigationOffset) ((ULONG_PTR)Object + (ULONG_PTR)PsMitigationOffset)
 
 BOOL KDUUnprotectProcess(
     _In_ PKDU_CONTEXT Context,
     _In_ ULONG_PTR ProcessId);
+
+BOOL KDUUnmitigateProcess(
+    _In_ PKDU_CONTEXT Context,
+    _In_ ULONG_PTR ProcessId,
+    _In_ ULONG PsNewMitigation);
 
 BOOL KDURunCommandPPL(
     _In_ PKDU_CONTEXT Context,
@@ -44,8 +55,13 @@ BOOL KDUDumpProcessMemory(
     _In_ PKDU_CONTEXT Context,
     _In_ HANDLE ProcessId);
 
-BOOL KDUControlProcess(
+BOOL KDUControlProcessProtections(
     _In_ PKDU_CONTEXT Context,
     _In_ ULONG_PTR ProcessId,
     _In_ PS_PROTECTED_SIGNER PsProtectionSigner,
     _In_ PS_PROTECTED_TYPE PsProtectionType);
+
+BOOL KDUControlProcessMitigationFlags2(
+    _In_ PKDU_CONTEXT Context,
+    _In_ ULONG_PTR ProcessId,
+    _In_ ULONG PsMitigations);

--- a/Source/Shared/ntos/ntos.h
+++ b/Source/Shared/ntos/ntos.h
@@ -1465,6 +1465,8 @@ typedef enum _PS_PROTECTED_SIGNER {
 #define PS_PROTECTED_AUDIT_MASK 0x08
 #define PS_PROTECTED_TYPE_MASK 0x07
 
+#define PS_NO_MITIGATIONS 0x00000000
+
 // from ph2
 #define PsProtectedValue(aSigner, aAudit, aType) ( \
     (((aSigner) & PS_PROTECTED_SIGNER_MASK) << 4) | \


### PR DESCRIPTION
# What
* new feature: zeros the process mitigation flags 1 and 2 inside a given EPROCESS block
* see https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-process_mitigation_policy for official docs
* dumped flags from a running MsMpEng.exe proc: 
  * Flags1: https://github.com/cailllev/EDR-Introspection/blob/22309dda3b19772fb2fc79e46ce2cb6a8009cd04/docs/MsMpEng-EPROCESS.txt#L229
  * Flags2: https://github.com/cailllev/EDR-Introspection/blob/22309dda3b19772fb2fc79e46ce2cb6a8009cd04/docs/MsMpEng-EPROCESS.txt#L231

# Why
## EDR Introspection
* I want to load my own DLL inside MsMpEng for tracing and introspection purposes
  * But, processes executed from ELAM drivers, i.e. EDR user-mode processes, may only load signed DLLs: "any non-Windows DLLs that get loaded into the protected service must be signed with the same certificate that was used to sign the anti-malware service.", see https://learn.microsoft.com/en-us/windows/win32/services/protecting-anti-malware-services-
  * --> if DLL loading should be achieved in EDRs, it must be self-reflective injection, or CodeIntegrity must be disabled, see below
```
Code Integrity determined that a process (\Device\HarddiskVolume4\ProgramData\Microsoft\Windows Defender\Platform\4.18.25080.5-0\MsMpEng.exe) attempted to load \Device\HarddiskVolume4\MyDumb.dll that did not meet the Custom 3 / Antimalware signing level requirements.
Log Name:  Microsoft-Windows-CodeIntegrity/Operational
Source:    CodeIntegrity
Event ID:  3033
Level:     Error
```
## More Info
* MsMpEng won't accept my unsigned DLL at LoadLibrary
  * code see https://github.com/cailllev/EDR-Introspection/blob/22309dda3b19772fb2fc79e46ce2cb6a8009cd04/EDRiShared/hooker.cpp#L185
  * Setup for unsuccessful load with my DLL: 
<img width="3207" height="1520" alt="image" src="https://github.com/user-attachments/assets/8afd399e-afb6-4905-a6fc-a55323835375" /> (see failed DLL load top left, see stripped kernel callbacks to get handle with full access on bottom left, see no loaded EDRHooker DLL with ProcExp the right)

  * Setup for successful load with MS signed DLL:  
<img width="2907" height="1031" alt="image" src="https://github.com/user-attachments/assets/52ca1b6d-c8a6-4eef-a2da-d10272cf79e3" /> (see DLL load middle left, see stripped kernel callbacks to get handle with full access on bottom left, see loaded DLL with ProcMon on the bottom middle and with ProcExp on the right)

# Now What
* as manually tested, values dumped via kernel debugger and described at https://www.ired.team/offensive-security/defense-evasion/preventing-3rd-party-dlls-from-injecting-into-your-processes#updateprocthreadattribute, MsMpEng will not load DLLs not signed by MS
* this zeroing of mitigation flags should allow loading of unsigned DLLs into MsMpEng -> no, CodeIntegrity denies it

# Further Research
(if anyone wonders / knows something / wants to invest time)
* ~are the mitigation stored somewhere else and periodically copied by MsMpEng?~
* ~is it even possible to LoadLibrary on MsMpEng with an unsigned DLL? (I guess with full access I could probably do reflective injection, but I wanted to know if this also works)~
  * self-reflective injection is the way, see https://github.com/evilele/EDR-Introspection/blob/master/InjectLoader/loader.cpp and https://github.com/evilele/EDR-Introspection/blob/877c4f327ef68c839eee7413585c64871334c529/EDRReflectiveHooker/dllmain.cpp#L45
* ~if MsMpEng protects its mitigation flags in a special way, is this behaviour of observed somewhere else, not only MsMpEng?~
* How to disable CodeIntegrity?
