### PR TITLE
KDUControlProcessMitigationFlags success w/o write

### DIFF
--- a/Source/Hamakaze/ps.cpp
+++ b/Source/Hamakaze/ps.cpp
@@ -640,6 +640,9 @@ BOOL KDUControlProcessMitigationFlags(
                             &Buffer1,
                             sizeof(ULONG));
                     }
+                    else {
+                        bResult1 = TRUE;
+                    }
 
                     if (TargetedFlags & PS_MITIGATION_FLAGS2) {
                         printf_s("[+] Overwriting MitigationFlags2\r\n");
@@ -647,6 +650,9 @@ BOOL KDUControlProcessMitigationFlags(
                             VirtualAddress2,
                             &Buffer2,
                             sizeof(ULONG));
+                    }
+                    else {
+                        bResult2 = TRUE;
                     }
 
                     if (bResult1 && bResult2) {


### PR DESCRIPTION
KDUControlProcessMitigationFlags - returning success when no write occurred.

bResult1 and bResult2 initialize TRUE at function start. If mitigation flags are not targeted (e.g., TargetedFlags & PS_MITIGATION_FLAGS1 is false) the following WriteKernelVM call is skipped. however result remains TRUE from initialization, causing final check (if (bResult1 && bResult2)) to return as true w/o writes.

If TargetedFlags only contains PS_MITIGATION_FLAGS1: the write to VirtualAddress1 executes and set bResult1 appropriately. write to VirtualAddress2 is skipped, and bResult2 remains TRUE functions reports success whether or not write is successful.